### PR TITLE
Fixes no validation on category dropdown which causes errors

### DIFF
--- a/backend/modules/catalog/actions/add.php
+++ b/backend/modules/catalog/actions/add.php
@@ -95,8 +95,8 @@ class BackendCatalogAdd extends BackendBaseActionAdd
 		$this->frm->addCheckbox('allow_comments', true);
 		$this->frm->addText('tags', null, null, 'inputText tagBox', 'inputTextError tagBox');
 		$this->frm->addDropdown('related_products', $this->allProductsGroupedByCategories, null, true);
-		
-		$this->frm->addDropdown('category_id', $this->categories, null);
+
+		$this->frm->addDropdown('category_id', $this->categories, SpoonFilter::getGetValue('category', null, null, 'int'));
 		
 		$specificationsHTML = array();
 		
@@ -153,7 +153,8 @@ class BackendCatalogAdd extends BackendBaseActionAdd
 			// required fields
 			$fields['title']->isFilled(BL::err('FieldIsRequired'));
 			$fields['summary']->isFilled(BL::err('FieldIsRequired'));
-			if($this->id == null) $fields['category_id']->isFilled(BL::err('FieldIsRequired'));
+			$fields['category_id']->isFilled(BL::err('FieldIsRequired'));
+			if($fields['category_id']->getValue() == 'no_category') $fields['category_id']->addError(BL::err('FieldIsRequired'));
 			
 			// validate meta
 			$this->meta->validate();

--- a/backend/modules/catalog/actions/edit.php
+++ b/backend/modules/catalog/actions/edit.php
@@ -171,6 +171,7 @@ class BackendCatalogEdit extends BackendBaseActionEdit
 			$fields['title']->isFilled(BL::err('FieldIsRequired'));
 			$fields['summary']->isFilled(BL::err('FieldIsRequired'));
 			$fields['category_id']->isFilled(BL::err('FieldIsRequired'));
+			if($fields['category_id']->getValue() == 'no_category') $fields['category_id']->addError(BL::err('FieldIsRequired'));
 
 			// validate meta
 			$this->meta->validate();

--- a/backend/modules/catalog/engine/model.php
+++ b/backend/modules/catalog/engine/model.php
@@ -549,7 +549,7 @@ class BackendCatalogModel
 			$tree = array();
 			
 			$categoryTree = self::buildTree($tree, $allCategories);
-			$categoryTree = array('0' => ucfirst(BL::lbl('None'))) + $categoryTree;
+			$categoryTree = array('no_category' => ucfirst(BL::getLabel('None'))) + $categoryTree;
 			
 			return $categoryTree;
 		}		

--- a/backend/modules/catalog/layout/css/catalog.css
+++ b/backend/modules/catalog/layout/css/catalog.css
@@ -39,9 +39,16 @@
 }
 
 .relatedProducts select{
-  height: 250px; 
+  height: 250px;
+  width: 100%;
 }
 
 .specificationInput input {
   margin-left: 20px;
+}
+
+/* Products */
+
+#catalog.catalogAddEdit #categoryId {
+	width: 170px;
 }

--- a/backend/modules/catalog/layout/templates/add.tpl
+++ b/backend/modules/catalog/layout/templates/add.tpl
@@ -84,7 +84,7 @@
 								<label for="price">{$lblPrice|ucfirst}</label>
 								{$txtPrice} {$txtPriceError}
 							</div>
-							<div class="options horizontal">
+							<div class="options">
 								<label for="categoryId">{$lblCategory|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
 								{$ddmCategoryId} {$ddmCategoryIdError}
 							</div>

--- a/backend/modules/catalog/layout/templates/edit.tpl
+++ b/backend/modules/catalog/layout/templates/edit.tpl
@@ -84,7 +84,7 @@
 									<label for="price">{$lblPrice|ucfirst}</label>
 									{$txtPrice} {$txtPriceError}
 								</div>
-								<div class="options horizontal">
+								<div class="options">
 									<label for="categoryId">{$lblCategory|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
 									{$ddmCategoryId} {$ddmCategoryIdError}
 								</div>


### PR DESCRIPTION
If you add or edit a product and don't choose a category, you could still add the product. This caused a Spoon exception when click on the product. The validation on the category_id dropdown didn't seem to be working.

I used the category validation from by the blog module. The "none" category gets a special index and the validation checks if this index is active. 

I also added a few lines of css to make the dropdown full width in the sidebar (just like the blog module does). And I noticed that the multi-selection box of related products was only 20px wide when I had only 1 product with a short title. So I also made this box take the full width of the sidebar.
