### PR TITLE
Decimal mysql datatype for prices

### DIFF
--- a/src/Backend/Modules/Catalog/Installer/Data/install.sql
+++ b/src/Backend/Modules/Catalog/Installer/Data/install.sql
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS `catalog_products` (
   `category_id` int(11) NOT NULL,
   `language` varchar(5) COLLATE utf8_unicode_ci NOT NULL,
   `title` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `price` int(11) NOT NULL,
+  `price` decimal(10,2) NOT NULL,
   `summary` text COLLATE utf8_unicode_ci NOT NULL,
   `text` text COLLATE utf8_unicode_ci,
   `allow_comments` enum('N','Y') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'N',


### PR DESCRIPTION
Using DECIMAL(10,2) instead of INT for prices is more correct. It also allows the user to enter prices with a comma, e.g. € 99,99
