### PR TITLE
Updating EditCategory.tpl

### DIFF
--- a/src/Backend/Modules/Catalog/Layout/Templates/EditCategory.tpl
+++ b/src/Backend/Modules/Catalog/Layout/Templates/EditCategory.tpl
@@ -32,7 +32,7 @@
 		</div>
 
 		<div id="tabSEO">
-			{include:{$BACKEND_CORE_PATH}/layout/templates/seo.tpl}
+			{include:{$BACKEND_CORE_PATH}/Layout/Templates/Seo.tpl}
 		</div>
 	</div>
 


### PR DESCRIPTION
Issue with non-capitalized path resulted in empty SEO tab under catalog > categories.
