### PR TITLE
Make code psr2 compliant

### DIFF
--- a/src/Backend/Modules/Catalog/Actions/Add.php
+++ b/src/Backend/Modules/Catalog/Actions/Add.php
@@ -26,216 +26,219 @@ use Backend\Modules\Tags\Engine\Model as BackendTagsModel;
  */
 class Add extends BackendBaseActionAdd
 {
-	/**
-	 * The product id
-	 *
-	 * @var	int
-	 */
-	private $id;
+    /**
+     * The product id
+     *
+     * @var	int
+     */
+    private $id;
 
-	/**
-	 * All categories
-	 *
-	 * @var	array
-	 */
-	private $categories;
+    /**
+     * All categories
+     *
+     * @var	array
+     */
+    private $categories;
 
-	/**
-	 * Products grouped by categories
-	 *
-	 * @var	array
-	 */
-	private $allProductsGroupedByCategories;
+    /**
+     * Products grouped by categories
+     *
+     * @var	array
+     */
+    private $allProductsGroupedByCategories;
 
-	/**
-	 * All specifications
-	 *
-	 * @var	array
-	 */
-	private $specifications;
+    /**
+     * All specifications
+     *
+     * @var	array
+     */
+    private $specifications;
 
-	/**
-	 * All brands
-	 *
-	 * @var	array
-	 */
-	private $brands;
+    /**
+     * All brands
+     *
+     * @var	array
+     */
+    private $brands;
 
-	/**
-	 * Execute the actions
-	 */
-	public function execute()
-	{
-		parent::execute();
+    /**
+     * Execute the actions
+     */
+    public function execute()
+    {
+        parent::execute();
 
-		$this->loadData();
-		$this->loadForm();
+        $this->loadData();
+        $this->loadForm();
 
-		$this->validateForm();
+        $this->validateForm();
 
-		$this->parse();
-		$this->display();
-	}
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Load the item data
-	 */
-	protected function loadData()
-	{
-		$this->id = $this->getParameter('product_id', 'int', null);
+    /**
+     * Load the item data
+     */
+    protected function loadData()
+    {
+        $this->id = $this->getParameter('product_id', 'int', null);
 
-		if($this->id != null) {
-			$this->record = BackendCatalogModel::get($this->id);
-		}
+        if ($this->id != null) {
+            $this->record = BackendCatalogModel::get($this->id);
+        }
 
-		// get categories
-		$this->categories = BackendCatalogModel::getCategories(true);
+        // get categories
+        $this->categories = BackendCatalogModel::getCategories(true);
 
-		// Get all products grouped by categories
-		$this->allProductsGroupedByCategories = BackendCatalogModel::getAllProductsGroupedByCategories();
+        // Get all products grouped by categories
+        $this->allProductsGroupedByCategories = BackendCatalogModel::getAllProductsGroupedByCategories();
 
-		// get specifications
-		$this->specifications = BackendCatalogModel::getSpecifications();
+        // get specifications
+        $this->specifications = BackendCatalogModel::getSpecifications();
 
-		// get brands
-		$this->brands = BackendCatalogModel::getBrandsForDropdown();
+        // get brands
+        $this->brands = BackendCatalogModel::getBrandsForDropdown();
+    }
 
-	}
+    /**
+     * Load the form
+     */
+    protected function loadForm()
+    {
+        $this->frm = new BackendForm('add');
 
-	/**
-	 * Load the form
-	 */
-	protected function loadForm()
-	{
-		$this->frm = new BackendForm('add');
-
-		// product fields
-		$this->frm->addText('title', null, null, 'inputText title', 'inputTextError title');
-		$this->frm->addEditor('summary');
-		$this->frm->addEditor('text');
-		$this->frm->addText('price', null, null, 'inputText price', 'inputTextError price');
-		$this->frm->addCheckbox('allow_comments', true);
-		$this->frm->addText('tags', null, null, 'inputText tagBox', 'inputTextError tagBox');
-		$this->frm->addDropdown('related_products', $this->allProductsGroupedByCategories, null, true);
+        // product fields
+        $this->frm->addText('title', null, null, 'inputText title', 'inputTextError title');
+        $this->frm->addEditor('summary');
+        $this->frm->addEditor('text');
+        $this->frm->addText('price', null, null, 'inputText price', 'inputTextError price');
+        $this->frm->addCheckbox('allow_comments', true);
+        $this->frm->addText('tags', null, null, 'inputText tagBox', 'inputTextError tagBox');
+        $this->frm->addDropdown('related_products', $this->allProductsGroupedByCategories, null, true);
 
 
-		$this->frm->addDropdown('category_id', $this->categories, \SpoonFilter::getGetValue('category', null, null, 'int'));
-		$this->frm->addDropdown('brand_id', $this->brands);
+        $this->frm->addDropdown('category_id', $this->categories, \SpoonFilter::getGetValue('category', null, null, 'int'));
+        $this->frm->addDropdown('brand_id', $this->brands);
         $this->frm->getField('brand_id')->setDefaultElement('');
 
-		$specificationsHTML = array();
+        $specificationsHTML = array();
 
-		// specifications
-		foreach($this->specifications as $specification) {
-			$specificationName = 'specification' . $specification['id'];
+        // specifications
+        foreach ($this->specifications as $specification) {
+            $specificationName = 'specification' . $specification['id'];
 
-			// @todo check if type is text or textarea..
-			$specificationText = $this->frm->addText($specificationName);
-			$specificationHTML = $specificationText->parse();
-			
-			// parse specification into template
-			$this->tpl->assign('id', $specification['id']);
-			$this->tpl->assign('label', $specification['title']);
-			$this->tpl->assign('field', $specificationHTML);
-			$this->tpl->assign('spec', true);
-			
-			$specificationsHTML[]['specification'] = $this->tpl->getContent(BACKEND_MODULE_PATH . '/Layout/Templates/Specification.tpl');
-		}
-		
-		$this->tpl->assign('specifications', $specificationsHTML);
-												
-		// meta
-		$this->meta = new BackendMeta($this->frm, null, 'title', true);
-	}
+            // @todo check if type is text or textarea..
+            $specificationText = $this->frm->addText($specificationName);
+            $specificationHTML = $specificationText->parse();
+            
+            // parse specification into template
+            $this->tpl->assign('id', $specification['id']);
+            $this->tpl->assign('label', $specification['title']);
+            $this->tpl->assign('field', $specificationHTML);
+            $this->tpl->assign('spec', true);
+            
+            $specificationsHTML[]['specification'] = $this->tpl->getContent(BACKEND_MODULE_PATH . '/Layout/Templates/Specification.tpl');
+        }
+        
+        $this->tpl->assign('specifications', $specificationsHTML);
+                                                
+        // meta
+        $this->meta = new BackendMeta($this->frm, null, 'title', true);
+    }
 
-	/**
-	 * Parse the page
-	 */
-	protected function parse()
-	{		
-		parent::parse();
-				
-		// get url
-		$url = BackendModel::getURLForBlock($this->URL->getModule(), 'detail');
-		$url404 = BackendModel::getURL(404);
-		
-		// parse additional variables
-		if($url404 != $url) $this->tpl->assign('detailURL', SITE_URL . $url);
-	}
+    /**
+     * Parse the page
+     */
+    protected function parse()
+    {
+        parent::parse();
+                
+        // get url
+        $url = BackendModel::getURLForBlock($this->URL->getModule(), 'detail');
+        $url404 = BackendModel::getURL(404);
+        
+        // parse additional variables
+        if ($url404 != $url) {
+            $this->tpl->assign('detailURL', SITE_URL . $url);
+        }
+    }
 
-	/**
-	 * Validate the form
-	 */
-	protected function validateForm()
-	{
-		if($this->frm->isSubmitted()) {			
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    protected function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            $this->frm->cleanupFields();
 
-			// validation
-			$fields = $this->frm->getFields();
-						
-			// required fields
-			$fields['title']->isFilled(BL::err('FieldIsRequired'));
-			$fields['summary']->isFilled(BL::err('FieldIsRequired'));
-			$fields['category_id']->isFilled(BL::err('FieldIsRequired'));
-			if($fields['category_id']->getValue() == 'no_category') $fields['category_id']->addError(BL::err('FieldIsRequired'));
-			
-			// validate meta
-			$this->meta->validate();
+            // validation
+            $fields = $this->frm->getFields();
+                        
+            // required fields
+            $fields['title']->isFilled(BL::err('FieldIsRequired'));
+            $fields['summary']->isFilled(BL::err('FieldIsRequired'));
+            $fields['category_id']->isFilled(BL::err('FieldIsRequired'));
+            if ($fields['category_id']->getValue() == 'no_category') {
+                $fields['category_id']->addError(BL::err('FieldIsRequired'));
+            }
+            
+            // validate meta
+            $this->meta->validate();
 
-			if($this->frm->isCorrect()) {
-				// build the item
-				$item['language'] = BL::getWorkingLanguage();
-				$item['title'] = $fields['title']->getValue();
-				$item['price'] = $fields['price']->getValue();
-				$item['summary'] = $fields['summary']->getValue();
-				$item['text'] = $fields['text']->getValue();
-				$item['allow_comments'] = $fields['allow_comments']->getChecked() ? 'Y' : 'N';
-				$item['num_comments'] = 0;
-				$item['sequence'] = BackendCatalogModel::getMaximumSequence() + 1;
-				$item['category_id'] = $fields['category_id']->getValue();
-				$item['brand_id'] = $fields['brand_id']->getValue();
-				$item['meta_id'] = $this->meta->save();
+            if ($this->frm->isCorrect()) {
+                // build the item
+                $item['language'] = BL::getWorkingLanguage();
+                $item['title'] = $fields['title']->getValue();
+                $item['price'] = $fields['price']->getValue();
+                $item['summary'] = $fields['summary']->getValue();
+                $item['text'] = $fields['text']->getValue();
+                $item['allow_comments'] = $fields['allow_comments']->getChecked() ? 'Y' : 'N';
+                $item['num_comments'] = 0;
+                $item['sequence'] = BackendCatalogModel::getMaximumSequence() + 1;
+                $item['category_id'] = $fields['category_id']->getValue();
+                $item['brand_id'] = $fields['brand_id']->getValue();
+                $item['meta_id'] = $this->meta->save();
 
-				// insert it
-				$item['id'] = BackendCatalogModel::insert($item);				
-				
-				$specificationArray = array();
-				
-				// loop trough specifications and insert values
-				foreach( $this->specifications as $specification) {
-					// build the specification 
-					$specificationArray['product_id'] = $item['id'];
-					$specificationArray['specification_id'] = $specification['id'];
+                // insert it
+                $item['id'] = BackendCatalogModel::insert($item);
+                
+                $specificationArray = array();
+                
+                // loop trough specifications and insert values
+                foreach ($this->specifications as $specification) {
+                    // build the specification
+                    $specificationArray['product_id'] = $item['id'];
+                    $specificationArray['specification_id'] = $specification['id'];
 
-					$field = 'specification' . $specification['id'];
-					
-					// check if there is an value
-					if($fields[$field]->getValue() != null) { 
-						$specificationArray['value'] = $fields[$field]->getValue();
-						
-						// insert specification with product id and value
-						BackendCatalogModel::insertSpecificationValue($specificationArray);
-					}
-				}
-				
-				// save the tags
-				BackendTagsModel::saveTags($item['id'], $fields['tags']->getValue(), $this->URL->getModule());
-				
-				// save the related products
-				BackendCatalogModel::saveRelatedProducts($item['id'], $this->frm->getField('related_products')->getValue());
-				
-				// add search index
-				BackendSearchModel::saveIndex($this->getModule(), $item['id'], array('title' => $item['title'], 'summary' => $item['summary'], 'text' => $item['text']));
+                    $field = 'specification' . $specification['id'];
+                    
+                    // check if there is an value
+                    if ($fields[$field]->getValue() != null) {
+                        $specificationArray['value'] = $fields[$field]->getValue();
+                        
+                        // insert specification with product id and value
+                        BackendCatalogModel::insertSpecificationValue($specificationArray);
+                    }
+                }
+                
+                // save the tags
+                BackendTagsModel::saveTags($item['id'], $fields['tags']->getValue(), $this->URL->getModule());
+                
+                // save the related products
+                BackendCatalogModel::saveRelatedProducts($item['id'], $this->frm->getField('related_products')->getValue());
+                
+                // add search index
+                BackendSearchModel::saveIndex($this->getModule(), $item['id'], array('title' => $item['title'], 'summary' => $item['summary'], 'text' => $item['text']));
 
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_add', $item);
-				
-				// redirect page
-				$this->redirect(
-					BackendModel::createURLForAction('index') . '&report=added&highlight=row-' . $item['id']
-				);
-			}
-		}
-	}
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_add', $item);
+                
+                // redirect page
+                $this->redirect(
+                    BackendModel::createURLForAction('index') . '&report=added&highlight=row-' . $item['id']
+                );
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/AddBrand.php
+++ b/src/Backend/Modules/Catalog/Actions/AddBrand.php
@@ -26,95 +26,88 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class AddBrand extends BackendBaseActionAdd
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
 
-		$this->loadForm();
-		$this->validateForm();
+        $this->loadForm();
+        $this->validateForm();
 
-		$this->parse();
-		$this->display();
-	}
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		$this->frm = new BackendForm('addBrand');
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        $this->frm = new BackendForm('addBrand');
 
-		$this->frm->addText('title');
-		$this->frm->addImage('image');
+        $this->frm->addText('title');
+        $this->frm->addImage('image');
 
-		$this->meta = new BackendMeta($this->frm, null, 'title', true);
-		$this->meta->setURLCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForBrand');
-	}
+        $this->meta = new BackendMeta($this->frm, null, 'title', true);
+        $this->meta->setURLCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForBrand');
+    }
 
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            $this->frm->cleanupFields();
 
-		if($this->frm->isSubmitted())
-		{
-			$this->frm->cleanupFields();
+            // validate fields
+            $this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
 
-			// validate fields
-			$this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
+            if ($this->frm->getField('image')->isFilled()) {
+                $this->frm->getField('image')->isAllowedExtension(array('jpg', 'png', 'gif', 'jpeg'), BL::err('JPGGIFAndPNGOnly'));
+                $this->frm->getField('image')->isAllowedMimeType(array('image/jpg', 'image/png', 'image/gif', 'image/jpeg'), BL::err('JPGGIFAndPNGOnly'));
+            }
 
-			if($this->frm->getField('image')->isFilled())
-			{
-				$this->frm->getField('image')->isAllowedExtension(array('jpg', 'png', 'gif', 'jpeg'), BL::err('JPGGIFAndPNGOnly'));
-				$this->frm->getField('image')->isAllowedMimeType(array('image/jpg', 'image/png', 'image/gif', 'image/jpeg'), BL::err('JPGGIFAndPNGOnly'));
-			}
+            $this->meta->validate();
 
-			$this->meta->validate();
+            if ($this->frm->isCorrect()) {
+                // build item
+                $item['title'] = $this->frm->getField('title')->getValue();
+                $item['meta_id'] = $this->meta->save();
+                $item['sequence'] = BackendCatalogModel::getMaximumCategorySequence() + 1;
+                $item['language'] = Language::getWorkingLanguage();
 
-			if($this->frm->isCorrect())
-			{
-				// build item
-				$item['title'] = $this->frm->getField('title')->getValue();
-				$item['meta_id'] = $this->meta->save();
-				$item['sequence'] = BackendCatalogModel::getMaximumCategorySequence() + 1;
-				$item['language'] = Language::getWorkingLanguage();
+                // the image path
+                $imagePath = FRONTEND_FILES_PATH . '/catalog/brands';
 
-				// the image path
-				$imagePath = FRONTEND_FILES_PATH . '/catalog/brands';
+                // create folders if needed
+                $fs = new Filesystem();
+                if (!$fs->exists($imagePath . '/source')) {
+                    $fs->mkdir($imagePath . '/source');
+                }
+                if (!$fs->exists($imagePath . '/150x150')) {
+                    $fs->mkdir($imagePath . '/150x150');
+                }
 
-				// create folders if needed
-				$fs = new Filesystem();
-				if(!$fs->exists($imagePath . '/source'))
-				{
-					$fs->mkdir($imagePath . '/source');
-				}
-				if(!$fs->exists($imagePath . '/150x150'))
-				{
-					$fs->mkdir($imagePath . '/150x150');
-				}
+                // is there an image provided?
+                if ($this->frm->getField('image')->isFilled()) {
+                    // build the image name
+                    $item['image'] = $this->meta->getUrl() . '.' . $this->frm->getField('image')->getExtension();
 
-				// is there an image provided?
-				if($this->frm->getField('image')->isFilled())
-				{
-					// build the image name
-					$item['image'] = $this->meta->getUrl() . '.' . $this->frm->getField('image')->getExtension();
+                    // upload the image & generate thumbnails
+                    $this->frm->getField('image')->generateThumbnails($imagePath, $item['image']);
+                }
+                // save the data
+                $item['id'] = BackendCatalogModel::insertBrand($item);
 
-					// upload the image & generate thumbnails
-					$this->frm->getField('image')->generateThumbnails($imagePath, $item['image']);
-				}
-				// save the data
-				$item['id'] = BackendCatalogModel::insertBrand($item);
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_add_brand', array('item' => $item));
 
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_add_brand', array('item' => $item));
-
-				// everything is saved, so redirect to the overview
-				$this->redirect(BackendModel::createURLForAction('brands') . '&report=added-brand&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']);
-			}
-		}
-	}
+                // everything is saved, so redirect to the overview
+                $this->redirect(BackendModel::createURLForAction('brands') . '&report=added-brand&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']);
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/AddCategory.php
+++ b/src/Backend/Modules/Catalog/Actions/AddCategory.php
@@ -25,103 +25,103 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class AddCategory extends BackendBaseActionAdd
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
 
-		$this->loadForm();
-		$this->validateForm();
+        $this->loadForm();
+        $this->validateForm();
 
-		$this->parse();
-		$this->display();
-	}
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		$this->frm = new BackendForm('addCategory');
-		
-		$this->frm->addText('title');
-		$this->frm->addImage('image');
-		
-		// get the categories
-		$categories = BackendCatalogModel::getCategories(true);
-		
-		$this->frm->addDropdown('parent_id', $categories);
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        $this->frm = new BackendForm('addCategory');
+        
+        $this->frm->addText('title');
+        $this->frm->addImage('image');
+        
+        // get the categories
+        $categories = BackendCatalogModel::getCategories(true);
+        
+        $this->frm->addDropdown('parent_id', $categories);
 
-		$this->meta = new BackendMeta($this->frm, null, 'title', true);
-		$this->meta->setURLCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForCategory');
-	}
-	
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			$this->frm->cleanupFields();
+        $this->meta = new BackendMeta($this->frm, null, 'title', true);
+        $this->meta->setURLCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForCategory');
+    }
+    
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            $this->frm->cleanupFields();
 
-			// validate fields
-			$this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
-			
-			if($this->frm->getField('image')->isFilled()) {
-				$this->frm->getField('image')->isAllowedExtension(array('jpg', 'png', 'gif', 'jpeg'), BL::err('JPGGIFAndPNGOnly'));
-				$this->frm->getField('image')->isAllowedMimeType(array('image/jpg', 'image/png', 'image/gif', 'image/jpeg'), BL::err('JPGGIFAndPNGOnly'));
-			}
-			
-			$this->meta->validate();
+            // validate fields
+            $this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
+            
+            if ($this->frm->getField('image')->isFilled()) {
+                $this->frm->getField('image')->isAllowedExtension(array('jpg', 'png', 'gif', 'jpeg'), BL::err('JPGGIFAndPNGOnly'));
+                $this->frm->getField('image')->isAllowedMimeType(array('image/jpg', 'image/png', 'image/gif', 'image/jpeg'), BL::err('JPGGIFAndPNGOnly'));
+            }
+            
+            $this->meta->validate();
 
-			if($this->frm->isCorrect()) {
-				// build item
-				$item['title'] = $this->frm->getField('title')->getValue();
-				$item['language'] = BL::getWorkingLanguage();
-				$item['meta_id'] = $this->meta->save();
-				$item['sequence'] = BackendCatalogModel::getMaximumCategorySequence() + 1;
-				if ($this->frm->getField('parent_id')->getValue() <> 'no_category') {
-					$item['parent_id'] = $this->frm->getField('parent_id')->getValue();
-				}
-				
-				// the image path
-				$imagePath = FRONTEND_FILES_PATH . '/' . $this->getModule() . '/catalog_categories';
-				
-				// create folders if needed
-				$fs = new Filesystem();
-				if (!$fs->exists($imagePath . '/source')) {
-				    $fs->mkdir($imagePath . '/source');
-				}
-				if (!$fs->exists($imagePath . '/150x150')) {
-				    $fs->mkdir($imagePath . '/150x150');
-				}
-								
-				// is there an image provided?
-				if($this->frm->getField('image')->isFilled()) {
-					// build the image name
-					$item['image'] = $this->meta->getUrl() . '.' . $this->frm->getField('image')->getExtension();
+            if ($this->frm->isCorrect()) {
+                // build item
+                $item['title'] = $this->frm->getField('title')->getValue();
+                $item['language'] = BL::getWorkingLanguage();
+                $item['meta_id'] = $this->meta->save();
+                $item['sequence'] = BackendCatalogModel::getMaximumCategorySequence() + 1;
+                if ($this->frm->getField('parent_id')->getValue() <> 'no_category') {
+                    $item['parent_id'] = $this->frm->getField('parent_id')->getValue();
+                }
+                
+                // the image path
+                $imagePath = FRONTEND_FILES_PATH . '/' . $this->getModule() . '/catalog_categories';
+                
+                // create folders if needed
+                $fs = new Filesystem();
+                if (!$fs->exists($imagePath . '/source')) {
+                    $fs->mkdir($imagePath . '/source');
+                }
+                if (!$fs->exists($imagePath . '/150x150')) {
+                    $fs->mkdir($imagePath . '/150x150');
+                }
+                                
+                // is there an image provided?
+                if ($this->frm->getField('image')->isFilled()) {
+                    // build the image name
+                    $item['image'] = $this->meta->getUrl() . '.' . $this->frm->getField('image')->getExtension();
 
-					// upload the image & generate thumbnails
-					$this->frm->getField('image')->generateThumbnails($imagePath, $item['image']);
-				}
-				
-				// save the data
-				$item['id'] = BackendCatalogModel::insertCategory($item);
-				
-				// trigger event
-				BackendModel::triggerEvent(
-					$this->getModule(),
-					'after_add_category',
-					array('item' => $item)
-				);
+                    // upload the image & generate thumbnails
+                    $this->frm->getField('image')->generateThumbnails($imagePath, $item['image']);
+                }
+                
+                // save the data
+                $item['id'] = BackendCatalogModel::insertCategory($item);
+                
+                // trigger event
+                BackendModel::triggerEvent(
+                    $this->getModule(),
+                    'after_add_category',
+                    array('item' => $item)
+                );
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(
-					BackendModel::createURLForAction('categories') . '&report=added-category&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']
-				);
-			}
-		}
-	}
+                // everything is saved, so redirect to the overview
+                $this->redirect(
+                    BackendModel::createURLForAction('categories') . '&report=added-category&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']
+                );
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/AddFile.php
+++ b/src/Backend/Modules/Catalog/Actions/AddFile.php
@@ -27,134 +27,136 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class AddFile extends BackendBaseActionAdd
 {
-	/**
-	 * The product id
-	 *
-	 * @var	int
-	 */
-	private $id;
+    /**
+     * The product id
+     *
+     * @var	int
+     */
+    private $id;
     
-	/**
-	 * The allowed file extensions
-	 *
-	 * @var	array
-	 *
-	 */
-	private $allowedExtensions = array('pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'pps', 'ppsx', 'zip');
+    /**
+     * The allowed file extensions
+     *
+     * @var	array
+     *
+     */
+    private $allowedExtensions = array('pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'pps', 'ppsx', 'zip');
     
-	/**
-	 * The product record
-	 *
-	 * @var	array
-	 */
-	private $product;
+    /**
+     * The product record
+     *
+     * @var	array
+     */
+    private $product;
 
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('product_id', 'int');
-		
-		if($this->id !== null && BackendCatalogModel::exists($this->id)) {
-			parent::execute();
-
-			$this->getData();
-			$this->loadForm();
-			$this->validateForm();
-			$this->parse();
-			$this->display();
-		}
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('product_id', 'int');
         
-		// the product does not exist
-		else $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
+        if ($this->id !== null && BackendCatalogModel::exists($this->id)) {
+            parent::execute();
 
-	/**
-	 * Get the necessary data
-	 */
-	private function getData()
-	{
-		$this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
-	}
+            $this->getData();
+            $this->loadForm();
+            $this->validateForm();
+            $this->parse();
+            $this->display();
+        }
+        
+        // the product does not exist
+        else {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		$this->frm = new BackendForm('addFile');
-		$this->frm->addText('title');
-		$this->frm->addFile('file');
-		$this->frm->getField('file')->setAttribute('extension', implode(', ', $this->allowedExtensions));
-	}
+    /**
+     * Get the necessary data
+     */
+    private function getData()
+    {
+        $this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
+    }
 
-	/**
-	 * Parses stuff into the template
-	 */
-	protected function parse()
-	{
-		parent::parse();
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        $this->frm = new BackendForm('addFile');
+        $this->frm->addText('title');
+        $this->frm->addFile('file');
+        $this->frm->getField('file')->setAttribute('extension', implode(', ', $this->allowedExtensions));
+    }
 
-		$this->tpl->assign('product', $this->product);
-	}
+    /**
+     * Parses stuff into the template
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			// cleanup the submitted fields, ignore fields that were added by hackers
-			$this->frm->cleanupFields();
+        $this->tpl->assign('product', $this->product);
+    }
 
-			// validate fields
-			$file = $this->frm->getField('file');
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            // cleanup the submitted fields, ignore fields that were added by hackers
+            $this->frm->cleanupFields();
+
+            // validate fields
+            $file = $this->frm->getField('file');
             
-			$this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
-			$file->isFilled(BL::err('FieldIsRequired'));
+            $this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
+            $file->isFilled(BL::err('FieldIsRequired'));
 
-			// validate the file
-			if($this->frm->getField('file')->isFilled()) {
-			    // file extension
-			    $this->frm->getField('file')->isAllowedExtension($this->allowedExtensions, BL::err('FileExtensionNotAllowed'));
-			}
+            // validate the file
+            if ($this->frm->getField('file')->isFilled()) {
+                // file extension
+                $this->frm->getField('file')->isAllowedExtension($this->allowedExtensions, BL::err('FileExtensionNotAllowed'));
+            }
 
-			// no errors?
-			if($this->frm->isCorrect()) {
-				// build file record to insert
-				$item['product_id'] = $this->product['id'];
-				$item['title'] = $this->frm->getField('title')->getValue();
+            // no errors?
+            if ($this->frm->isCorrect()) {
+                // build file record to insert
+                $item['product_id'] = $this->product['id'];
+                $item['title'] = $this->frm->getField('title')->getValue();
 
-				// the file path
-				$filePath = FRONTEND_FILES_PATH . '/' . $this->getModule() . '/' . $item['product_id'] . '/source';
+                // the file path
+                $filePath = FRONTEND_FILES_PATH . '/' . $this->getModule() . '/' . $item['product_id'] . '/source';
                 
-				// create folders if needed
-				$fs = new Filesystem();
-				if (!$fs->exists($filePath)) {
-				    $fs->mkdir($filePath);
-				}
-				
-				// file provided?
-				if($file->isFilled()) {
-					// build the file name
-					$item['filename'] = time() . '.' . $file->getExtension();
-
-					// upload the file
-					$file->moveFile($filePath . '/' . $item['filename']);
-				}
+                // create folders if needed
+                $fs = new Filesystem();
+                if (!$fs->exists($filePath)) {
+                    $fs->mkdir($filePath);
+                }
                 
-				$item['sequence'] = BackendCatalogModel::getMaximumFilesSequence($item['product_id'])+1;
+                // file provided?
+                if ($file->isFilled()) {
+                    // build the file name
+                    $item['filename'] = time() . '.' . $file->getExtension();
 
-				// insert it
-				$item['id'] = BackendCatalogModel::saveFile($item);
+                    // upload the file
+                    $file->moveFile($filePath . '/' . $item['filename']);
+                }
+                
+                $item['sequence'] = BackendCatalogModel::getMaximumFilesSequence($item['product_id'])+1;
 
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_add_file', array('item' => $item));
+                // insert it
+                $item['id'] = BackendCatalogModel::saveFile($item);
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(BackendModel::createURLForAction('media') . '&product_id=' . $item['product_id'] . '&report=added&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id'] . '#tabFiles');
-			}
-		}
-	}
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_add_file', array('item' => $item));
+
+                // everything is saved, so redirect to the overview
+                $this->redirect(BackendModel::createURLForAction('media') . '&product_id=' . $item['product_id'] . '&report=added&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id'] . '#tabFiles');
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/AddImage.php
+++ b/src/Backend/Modules/Catalog/Actions/AddImage.php
@@ -20,124 +20,126 @@ use Backend\Modules\Catalog\Engine\Helper as BackendCatalogHelper;
 /**
  * This is the add action, it will display a form to add an image to a product.
  *
- * @author Bart De Clercq <info@lexxweb.be> 
+ * @author Bart De Clercq <info@lexxweb.be>
  * @author Tim van Wolfswinkel <tim@webleads.nl>
  */
 class AddImage extends BackendBaseActionAdd
 {
-	/**
-	 * The product id
-	 *
-	 * @var	int
-	 */
-	private $id;
+    /**
+     * The product id
+     *
+     * @var	int
+     */
+    private $id;
 
-	/**
-	 * The product record
-	 *
-	 * @var	array
-	 */
-	private $product;
+    /**
+     * The product record
+     *
+     * @var	array
+     */
+    private $product;
 
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('product_id', 'int');
-		
-		if($this->id !== null && BackendCatalogModel::exists($this->id)) {
-			parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('product_id', 'int');
+        
+        if ($this->id !== null && BackendCatalogModel::exists($this->id)) {
+            parent::execute();
 
-			$this->getData();
-			$this->loadForm();
-			$this->validateForm();
-			$this->parse();
-			$this->display();
-		}
-		
-		// the product does not exist
-		else $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
+            $this->getData();
+            $this->loadForm();
+            $this->validateForm();
+            $this->parse();
+            $this->display();
+        }
+        
+        // the product does not exist
+        else {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 
-	/**
-	 * Get the necessary data
-	 */
-	private function getData()
-	{
-		$this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
-	}
+    /**
+     * Get the necessary data
+     */
+    private function getData()
+    {
+        $this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
+    }
 
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		$this->frm = new BackendForm('addImage');
-		$this->frm->addText('title');
-		$this->frm->addImage('image');
-	}
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        $this->frm = new BackendForm('addImage');
+        $this->frm->addText('title');
+        $this->frm->addImage('image');
+    }
 
-	/**
-	 * Parses stuff into the template
-	 */
-	protected function parse()
-	{
-		parent::parse();
+    /**
+     * Parses stuff into the template
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-		$this->tpl->assign('product', $this->product);
-	}
+        $this->tpl->assign('product', $this->product);
+    }
 
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			// cleanup the submitted fields, ignore fields that were added by hackers
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            // cleanup the submitted fields, ignore fields that were added by hackers
+            $this->frm->cleanupFields();
 
-			// validate fields
-			$image = $this->frm->getField('image');
+            // validate fields
+            $image = $this->frm->getField('image');
 
-			$this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
-			$image->isFilled(BL::err('FieldIsRequired'));
+            $this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
+            $image->isFilled(BL::err('FieldIsRequired'));
 
-			// no errors?
-			if($this->frm->isCorrect()) {
-				// build image record to insert
-				$item['product_id'] = $this->product['id'];
-				$item['title'] = $this->frm->getField('title')->getValue();
+            // no errors?
+            if ($this->frm->isCorrect()) {
+                // build image record to insert
+                $item['product_id'] = $this->product['id'];
+                $item['title'] = $this->frm->getField('title')->getValue();
 
-				// set files path for this record
-				$path = FRONTEND_FILES_PATH . '/' . $this->module . '/' . $item['product_id'];
+                // set files path for this record
+                $path = FRONTEND_FILES_PATH . '/' . $this->module . '/' . $item['product_id'];
 
-				// set formats
-				$formats = array();
-				$formats[] = array('size' => '64x64', 'allow_enlargement' => true, 'force_aspect_ratio' => false);
-				$formats[] = array('size' => '128x128', 'allow_enlargement' => true, 'force_aspect_ratio' => false);
-				$formats[] = array('size' => BackendModel::getModuleSetting($this->URL->getModule(), 'width1') . 'x' . BackendModel::getModuleSetting($this->URL->getModule(), 'height1'), 'allow_enlargement' => BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment1'), 'force_aspect_ratio' => BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio1'));
-				$formats[] = array('size' => BackendModel::getModuleSetting($this->URL->getModule(), 'width2') . 'x' . BackendModel::getModuleSetting($this->URL->getModule(), 'height2'), 'allow_enlargement' => BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment2'), 'force_aspect_ratio' => BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio2'));
-				$formats[] = array('size' => BackendModel::getModuleSetting($this->URL->getModule(), 'width3') . 'x' . BackendModel::getModuleSetting($this->URL->getModule(), 'height3'), 'allow_enlargement' => BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment3'), 'force_aspect_ratio' => BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio3'));
+                // set formats
+                $formats = array();
+                $formats[] = array('size' => '64x64', 'allow_enlargement' => true, 'force_aspect_ratio' => false);
+                $formats[] = array('size' => '128x128', 'allow_enlargement' => true, 'force_aspect_ratio' => false);
+                $formats[] = array('size' => BackendModel::getModuleSetting($this->URL->getModule(), 'width1') . 'x' . BackendModel::getModuleSetting($this->URL->getModule(), 'height1'), 'allow_enlargement' => BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment1'), 'force_aspect_ratio' => BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio1'));
+                $formats[] = array('size' => BackendModel::getModuleSetting($this->URL->getModule(), 'width2') . 'x' . BackendModel::getModuleSetting($this->URL->getModule(), 'height2'), 'allow_enlargement' => BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment2'), 'force_aspect_ratio' => BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio2'));
+                $formats[] = array('size' => BackendModel::getModuleSetting($this->URL->getModule(), 'width3') . 'x' . BackendModel::getModuleSetting($this->URL->getModule(), 'height3'), 'allow_enlargement' => BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment3'), 'force_aspect_ratio' => BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio3'));
 
-				// set the filename
-				$item['filename'] = time() . '.' . $image->getExtension();
-				$item['sequence'] = BackendCatalogModel::getMaximumImagesSequence($item['product_id'])+1;
+                // set the filename
+                $item['filename'] = time() . '.' . $image->getExtension();
+                $item['sequence'] = BackendCatalogModel::getMaximumImagesSequence($item['product_id'])+1;
 
-				// add images
-				BackendCatalogHelper::addImages($image, $path, $item['filename'], $formats);
+                // add images
+                BackendCatalogHelper::addImages($image, $path, $item['filename'], $formats);
 
-				// save the item
-				$item['id'] = BackendCatalogModel::saveImage($item);
+                // save the item
+                $item['id'] = BackendCatalogModel::saveImage($item);
 
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_add_image', array('item' => $item));
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_add_image', array('item' => $item));
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(
-					BackendModel::createURLForAction('media') . '&product_id=' . $item['product_id'] . '&report=added&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']
-				);
-			}
-		}
-	}
+                // everything is saved, so redirect to the overview
+                $this->redirect(
+                    BackendModel::createURLForAction('media') . '&product_id=' . $item['product_id'] . '&report=added&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']
+                );
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/AddSpecification.php
+++ b/src/Backend/Modules/Catalog/Actions/AddSpecification.php
@@ -23,64 +23,64 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class AddSpecification extends BackendBaseActionAdd
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
 
-		$this->loadForm();
-		$this->validateForm();
+        $this->loadForm();
+        $this->validateForm();
 
-		$this->parse();
-		$this->display();
-	}
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		$this->frm = new BackendForm('addSpecification');
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        $this->frm = new BackendForm('addSpecification');
 
-		$this->frm->addText('title');
-		
-		$this->meta = new BackendMeta($this->frm, null, 'title', true);
-		$this->meta->setURLCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForSpecification');
-	}
+        $this->frm->addText('title');
+        
+        $this->meta = new BackendMeta($this->frm, null, 'title', true);
+        $this->meta->setURLCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForSpecification');
+    }
 
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            $this->frm->cleanupFields();
 
-			// validate fields
-			$this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
-						
-			$this->meta->validate();
+            // validate fields
+            $this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
+                        
+            $this->meta->validate();
 
-			if($this->frm->isCorrect()) {
-				// build item
-				$item['title'] = $this->frm->getField('title')->getValue();
-				$item['language'] = BL::getWorkingLanguage();
-				$item['meta_id'] = $this->meta->save();
-				$item['sequence'] = BackendCatalogModel::getMaximumSpecificationSequence() + 1;
-				
-				// save the data
-				$item['id'] = BackendCatalogModel::insertSpecification($item);
-			
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_add_specification', array('item' => $item));
+            if ($this->frm->isCorrect()) {
+                // build item
+                $item['title'] = $this->frm->getField('title')->getValue();
+                $item['language'] = BL::getWorkingLanguage();
+                $item['meta_id'] = $this->meta->save();
+                $item['sequence'] = BackendCatalogModel::getMaximumSpecificationSequence() + 1;
+                
+                // save the data
+                $item['id'] = BackendCatalogModel::insertSpecification($item);
+            
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_add_specification', array('item' => $item));
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(
-					BackendModel::createURLForAction('specifications') . '&report=added-specification&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']
-				);
-			}
-		}
-	}    
+                // everything is saved, so redirect to the overview
+                $this->redirect(
+                    BackendModel::createURLForAction('specifications') . '&report=added-specification&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']
+                );
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/AddVideo.php
+++ b/src/Backend/Modules/Catalog/Actions/AddVideo.php
@@ -23,101 +23,103 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class AddVideo extends BackendBaseActionAdd
 {
-	/**
-	 * The product id
-	 *
-	 * @var	int
-	 */
-	private $id;
+    /**
+     * The product id
+     *
+     * @var	int
+     */
+    private $id;
 
-	/**
-	 * The product record
-	 *
-	 * @var	array
-	 */
-	private $product;
+    /**
+     * The product record
+     *
+     * @var	array
+     */
+    private $product;
 
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('product_id', 'int');
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('product_id', 'int');
         
-		if($this->id !== null && BackendCatalogModel::exists($this->id)) {
-			parent::execute();
+        if ($this->id !== null && BackendCatalogModel::exists($this->id)) {
+            parent::execute();
 
-			$this->getData();
-			$this->loadForm();
-			$this->validateForm();
-			$this->parse();
-			$this->display();
-		}
+            $this->getData();
+            $this->loadForm();
+            $this->validateForm();
+            $this->parse();
+            $this->display();
+        }
         
-		// the product does not exist
-		else $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
+        // the product does not exist
+        else {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 
-	/**
-	 * Get the necessary data
-	 */
-	private function getData()
-	{
-		$this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
-	}
+    /**
+     * Get the necessary data
+     */
+    private function getData()
+    {
+        $this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
+    }
 
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		$this->frm = new BackendForm('addVideo');
-		$this->frm->addText('title');
-		$this->frm->addTextArea('video');
-	}
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        $this->frm = new BackendForm('addVideo');
+        $this->frm->addText('title');
+        $this->frm->addTextArea('video');
+    }
 
-	/**
-	 * Parses stuff into the template
-	 */
-	protected function parse()
-	{
-		parent::parse();
+    /**
+     * Parses stuff into the template
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-		$this->tpl->assign('product', $this->product);
-	}
+        $this->tpl->assign('product', $this->product);
+    }
 
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			// cleanup the submitted fields, ignore fields that were added by hackers
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            // cleanup the submitted fields, ignore fields that were added by hackers
+            $this->frm->cleanupFields();
 
-			// validate fields
-			$this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
-			$this->frm->getField('video')->isFilled(BL::err('FieldIsRequired'));
-			        
-			// no errors?
-			if($this->frm->isCorrect()) {
-				// build video record to insert
-				$item['product_id'] = $this->product['id'];
-				$item['title'] = $this->frm->getField('title')->getValue();
-				$item['embedded_url'] = $this->frm->getField('video')->getValue();
-				$item['sequence'] = BackendCatalogModel::getMaximumVideosSequence($item['product_id'])+1;
+            // validate fields
+            $this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
+            $this->frm->getField('video')->isFilled(BL::err('FieldIsRequired'));
+                    
+            // no errors?
+            if ($this->frm->isCorrect()) {
+                // build video record to insert
+                $item['product_id'] = $this->product['id'];
+                $item['title'] = $this->frm->getField('title')->getValue();
+                $item['embedded_url'] = $this->frm->getField('video')->getValue();
+                $item['sequence'] = BackendCatalogModel::getMaximumVideosSequence($item['product_id'])+1;
 
-				// save the item
-				$item['id'] = BackendCatalogModel::saveVideo($item);
+                // save the item
+                $item['id'] = BackendCatalogModel::saveVideo($item);
 
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_add_video', array('item' => $item));
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_add_video', array('item' => $item));
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(
-					BackendModel::createURLForAction('media') . '&product_id=' . $item['product_id'] . '&report=added&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id'] . '#tabVideos'
-				);
-			}
-		}
-	}
+                // everything is saved, so redirect to the overview
+                $this->redirect(
+                    BackendModel::createURLForAction('media') . '&product_id=' . $item['product_id'] . '&report=added&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id'] . '#tabVideos'
+                );
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/Brands.php
+++ b/src/Backend/Modules/Catalog/Actions/Brands.php
@@ -24,45 +24,42 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class Brands extends BackendBaseActionIndex
 {
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
+        $this->loadDataGrid();
 
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
+        $this->parse();
+        $this->display();
+    }
 
-		parent::execute();
-		$this->loadDataGrid();
+    /**
+     * Load the dataGrid
+     */
+    private function loadDataGrid()
+    {
+        $this->dataGrid = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_BRANDS, array(BL::getWorkingLanguage()));
 
-		$this->parse();
-		$this->display();
-	}
+        // check if this action is allowed
+        if (BackendAuthentication::isAllowedAction('EditBrand')) {
+            $this->dataGrid->setColumnURL('title', BackendModel::createURLForAction('edit_brand') . '&amp;id=[id]');
 
-	/**
-	 * Load the dataGrid
-	 */
-	private function loadDataGrid()
-	{
-		$this->dataGrid = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_BRANDS, array(BL::getWorkingLanguage()));
+            $this->dataGrid->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_brand') . '&amp;id=[id]', BL::lbl('Edit'));
+        }
 
-		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('EditBrand'))
-		{
-			$this->dataGrid->setColumnURL('title', BackendModel::createURLForAction('edit_brand') . '&amp;id=[id]');
+        // sequence
+        $this->dataGrid->enableSequenceByDragAndDrop();
+        $this->dataGrid->setAttributes(array('data-action' => 'SequenceBrands'));
+    }
 
-			$this->dataGrid->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_brand') . '&amp;id=[id]', BL::lbl('Edit'));
-		}
-
-		// sequence
-		$this->dataGrid->enableSequenceByDragAndDrop();
-		$this->dataGrid->setAttributes(array('data-action' => 'SequenceBrands'));
-	}
-
-	/**
-	 * Parse & display the page
-	 */
-	protected function parse()
-	{
-		$this->tpl->assign('dataGrid', (string)$this->dataGrid->getContent());
-	}
+    /**
+     * Parse & display the page
+     */
+    protected function parse()
+    {
+        $this->tpl->assign('dataGrid', (string)$this->dataGrid->getContent());
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/Comments.php
+++ b/src/Backend/Modules/Catalog/Actions/Comments.php
@@ -26,197 +26,197 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class Comments extends BackendBaseActionIndex
 {
-	/**
-	 * DataGrids
-	 *
-	 * @var	BackendDataGridDB
-	 */
-	private $dgPublished, $dgModeration, $dgSpam;
+    /**
+     * DataGrids
+     *
+     * @var	BackendDataGridDB
+     */
+    private $dgPublished, $dgModeration, $dgSpam;
 
-	/**
-	 * Add productdata into the comment
-	 *
-	 * @param  string $text The comment.
-	 * @param string $title The title for the product.
-	 * @param string $URL The URL for the product.
-	 * @param int $id The id of the comment.
-	 * @return string
-	 */
-	public static function addProductData($text, $title, $URL, $id)
-	{
-		// reset URL
-		$URL = BackendModel::getURLForBlock('Catalog', 'Detail') . '/' . $URL . '#comment-' . $id;
+    /**
+     * Add productdata into the comment
+     *
+     * @param  string $text The comment.
+     * @param string $title The title for the product.
+     * @param string $URL The URL for the product.
+     * @param int $id The id of the comment.
+     * @return string
+     */
+    public static function addProductData($text, $title, $URL, $id)
+    {
+        // reset URL
+        $URL = BackendModel::getURLForBlock('Catalog', 'Detail') . '/' . $URL . '#comment-' . $id;
 
-		// build HTML
-		return '<p><em>' . sprintf(BL::msg('CommentOnWithURL'), $URL, $title) . '</em></p>' . "\n" . (string) $text;
-	}
+        // build HTML
+        return '<p><em>' . sprintf(BL::msg('CommentOnWithURL'), $URL, $title) . '</em></p>' . "\n" . (string) $text;
+    }
 
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
-		$this->loadDataGrids();
-		$this->parse();
-		$this->display();
-	}
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
+        $this->loadDataGrids();
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Loads the datagrids
-	 */
-	private function loadDataGrids()
-	{
-		/*
-		 * DataGrid for the published comments.
-		 */
-		$this->dgPublished = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_COMMENTS, array('published', BL::getWorkingLanguage()));
-		
-		// active tab
-		$this->dgPublished->setActiveTab('tabPublished');
+    /**
+     * Loads the datagrids
+     */
+    private function loadDataGrids()
+    {
+        /*
+         * DataGrid for the published comments.
+         */
+        $this->dgPublished = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_COMMENTS, array('published', BL::getWorkingLanguage()));
+        
+        // active tab
+        $this->dgPublished->setActiveTab('tabPublished');
 
-		// num items per page
-		$this->dgPublished->setPagingLimit(30);
+        // num items per page
+        $this->dgPublished->setPagingLimit(30);
 
-		// header labels
-		$this->dgPublished->setHeaderLabels(array('created_on' => ucfirst(BL::lbl('Date')), 'text' => ucfirst(BL::lbl('Comment'))));
+        // header labels
+        $this->dgPublished->setHeaderLabels(array('created_on' => ucfirst(BL::lbl('Date')), 'text' => ucfirst(BL::lbl('Comment'))));
 
-		// add the multicheckbox column
-		$this->dgPublished->setMassActionCheckboxes('checkbox', '[id]');
+        // add the multicheckbox column
+        $this->dgPublished->setMassActionCheckboxes('checkbox', '[id]');
 
-		// assign column functions
-		$this->dgPublished->setColumnFunction(array(new BackendDataGridFunctions(), 'getTimeAgo'), '[created_on]', 'created_on', true);
-		$this->dgPublished->setColumnFunction(array(new BackendDataGridFunctions(), 'cleanupPlaintext'), '[text]', 'text', true);
-		$this->dgPublished->setColumnFunction(array(__CLASS__, 'addProductData'), array('[text]', '[product_title]', '[product_url]', '[id]'), 'text', true);
+        // assign column functions
+        $this->dgPublished->setColumnFunction(array(new BackendDataGridFunctions(), 'getTimeAgo'), '[created_on]', 'created_on', true);
+        $this->dgPublished->setColumnFunction(array(new BackendDataGridFunctions(), 'cleanupPlaintext'), '[text]', 'text', true);
+        $this->dgPublished->setColumnFunction(array(__CLASS__, 'addProductData'), array('[text]', '[product_title]', '[product_url]', '[id]'), 'text', true);
 
-		// sorting
-		$this->dgPublished->setSortingColumns(array('created_on', 'text', 'author'), 'created_on');
-		$this->dgPublished->setSortParameter('desc');
+        // sorting
+        $this->dgPublished->setSortingColumns(array('created_on', 'text', 'author'), 'created_on');
+        $this->dgPublished->setSortParameter('desc');
 
-		// hide columns
-		$this->dgPublished->setColumnsHidden('product_id', 'product_title', 'product_url');
+        // hide columns
+        $this->dgPublished->setColumnsHidden('product_id', 'product_title', 'product_url');
 
-		// add mass action dropdown
-		$ddmMassAction = new \SpoonFormDropdown('action', array('moderation' => BL::lbl('MoveToModeration'), 'spam' => BL::lbl('MoveToSpam'), 'delete' => BL::lbl('Delete')), 'spam');
-		$ddmMassAction->setAttribute('id', 'actionPublished');
-		$ddmMassAction->setOptionAttributes('delete', array('data-message-id' => 'confirmDeletePublished'));
-		$ddmMassAction->setOptionAttributes('spam', array('data-message-id' => 'confirmSpamPublished'));
-		$this->dgPublished->setMassAction($ddmMassAction);
+        // add mass action dropdown
+        $ddmMassAction = new \SpoonFormDropdown('action', array('moderation' => BL::lbl('MoveToModeration'), 'spam' => BL::lbl('MoveToSpam'), 'delete' => BL::lbl('Delete')), 'spam');
+        $ddmMassAction->setAttribute('id', 'actionPublished');
+        $ddmMassAction->setOptionAttributes('delete', array('data-message-id' => 'confirmDeletePublished'));
+        $ddmMassAction->setOptionAttributes('spam', array('data-message-id' => 'confirmSpamPublished'));
+        $this->dgPublished->setMassAction($ddmMassAction);
 
-		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('EditComment')) {
-			$this->dgPublished->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_comment') . '&amp;id=[id]', BL::lbl('Edit'));
-		}
+        // check if this action is allowed
+        if (BackendAuthentication::isAllowedAction('EditComment')) {
+            $this->dgPublished->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_comment') . '&amp;id=[id]', BL::lbl('Edit'));
+        }
 
-		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('MassCommentAction')) {
-			$this->dgPublished->addColumn('mark_as_spam', null, BL::lbl('MarkAsSpam'), BackendModel::createURLForAction('mass_comment_action') . '&amp;id=[id]&amp;from=published&amp;action=spam', BL::lbl('MarkAsSpam'));
-		}
+        // check if this action is allowed
+        if (BackendAuthentication::isAllowedAction('MassCommentAction')) {
+            $this->dgPublished->addColumn('mark_as_spam', null, BL::lbl('MarkAsSpam'), BackendModel::createURLForAction('mass_comment_action') . '&amp;id=[id]&amp;from=published&amp;action=spam', BL::lbl('MarkAsSpam'));
+        }
 
-		/*
-		 * DataGrid for the comments that are awaiting moderation.
-		 */
-		$this->dgModeration = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_COMMENTS, array('moderation', BL::getWorkingLanguage()));
-			
-		// active tab
-		$this->dgModeration->setActiveTab('tabModeration');
+        /*
+         * DataGrid for the comments that are awaiting moderation.
+         */
+        $this->dgModeration = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_COMMENTS, array('moderation', BL::getWorkingLanguage()));
+            
+        // active tab
+        $this->dgModeration->setActiveTab('tabModeration');
 
-		// num items per page
-		$this->dgModeration->setPagingLimit(30);
+        // num items per page
+        $this->dgModeration->setPagingLimit(30);
 
-		// header labels
-		$this->dgModeration->setHeaderLabels(array('created_on' => ucfirst(BL::lbl('Date')), 'text' => ucfirst(BL::lbl('Comment'))));
+        // header labels
+        $this->dgModeration->setHeaderLabels(array('created_on' => ucfirst(BL::lbl('Date')), 'text' => ucfirst(BL::lbl('Comment'))));
 
-		// add the multicheckbox column
-		$this->dgModeration->setMassActionCheckboxes('checkbox', '[id]');
+        // add the multicheckbox column
+        $this->dgModeration->setMassActionCheckboxes('checkbox', '[id]');
 
-		// assign column functions
-		$this->dgModeration->setColumnFunction(array(new BackendDataGridFunctions(), 'getTimeAgo'), '[created_on]', 'created_on', true);
-		$this->dgModeration->setColumnFunction(array(new BackendDataGridFunctions(), 'cleanupPlaintext'), '[text]', 'text', true);
-		$this->dgModeration->setColumnFunction(array(__CLASS__, 'addProductData'), array('[text]', '[product_title]', '[product_url]', '[id]'), 'text', true);
+        // assign column functions
+        $this->dgModeration->setColumnFunction(array(new BackendDataGridFunctions(), 'getTimeAgo'), '[created_on]', 'created_on', true);
+        $this->dgModeration->setColumnFunction(array(new BackendDataGridFunctions(), 'cleanupPlaintext'), '[text]', 'text', true);
+        $this->dgModeration->setColumnFunction(array(__CLASS__, 'addProductData'), array('[text]', '[product_title]', '[product_url]', '[id]'), 'text', true);
 
-		// sorting
-		$this->dgModeration->setSortingColumns(array('created_on', 'text', 'author'), 'created_on');
-		$this->dgModeration->setSortParameter('desc');
+        // sorting
+        $this->dgModeration->setSortingColumns(array('created_on', 'text', 'author'), 'created_on');
+        $this->dgModeration->setSortParameter('desc');
 
-		// hide columns
-		$this->dgModeration->setColumnsHidden('product_id', 'product_title', 'product_url');
+        // hide columns
+        $this->dgModeration->setColumnsHidden('product_id', 'product_title', 'product_url');
 
-		// add mass action dropdown
-		$ddmMassAction = new \SpoonFormDropdown('action', array('published' => BL::lbl('MoveToPublished'), 'spam' => BL::lbl('MoveToSpam'), 'delete' => BL::lbl('Delete')), 'published');
-		$ddmMassAction->setAttribute('id', 'actionModeration');
-		$ddmMassAction->setOptionAttributes('delete', array('data-message-id' => 'confirmDeleteModeration'));
-		$ddmMassAction->setOptionAttributes('spam', array('data-message-id' => 'confirmSpamModeration'));
-		$this->dgModeration->setMassAction($ddmMassAction);
+        // add mass action dropdown
+        $ddmMassAction = new \SpoonFormDropdown('action', array('published' => BL::lbl('MoveToPublished'), 'spam' => BL::lbl('MoveToSpam'), 'delete' => BL::lbl('Delete')), 'published');
+        $ddmMassAction->setAttribute('id', 'actionModeration');
+        $ddmMassAction->setOptionAttributes('delete', array('data-message-id' => 'confirmDeleteModeration'));
+        $ddmMassAction->setOptionAttributes('spam', array('data-message-id' => 'confirmSpamModeration'));
+        $this->dgModeration->setMassAction($ddmMassAction);
 
-		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('EditComment')) {
-			$this->dgModeration->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_comment') . '&amp;id=[id]', BL::lbl('Edit'));
-		}
+        // check if this action is allowed
+        if (BackendAuthentication::isAllowedAction('EditComment')) {
+            $this->dgModeration->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_comment') . '&amp;id=[id]', BL::lbl('Edit'));
+        }
 
-		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('MassCommentAction')) {
-			$this->dgModeration->addColumn('approve', null, BL::lbl('Approve'), BackendModel::createURLForAction('mass_comment_action') . '&amp;id=[id]&amp;from=published&amp;action=published', BL::lbl('Approve'));
-		}
+        // check if this action is allowed
+        if (BackendAuthentication::isAllowedAction('MassCommentAction')) {
+            $this->dgModeration->addColumn('approve', null, BL::lbl('Approve'), BackendModel::createURLForAction('mass_comment_action') . '&amp;id=[id]&amp;from=published&amp;action=published', BL::lbl('Approve'));
+        }
 
-		/*
-		 * DataGrid for the comments that are marked as spam
-		 */
-		$this->dgSpam = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_COMMENTS, array('spam', BL::getWorkingLanguage()));
+        /*
+         * DataGrid for the comments that are marked as spam
+         */
+        $this->dgSpam = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_COMMENTS, array('spam', BL::getWorkingLanguage()));
 
-		// active tab
-		$this->dgSpam->setActiveTab('tabSpam');
+        // active tab
+        $this->dgSpam->setActiveTab('tabSpam');
 
-		// num items per page
-		$this->dgSpam->setPagingLimit(30);
+        // num items per page
+        $this->dgSpam->setPagingLimit(30);
 
-		// header labels
-		$this->dgSpam->setHeaderLabels(array('created_on' => ucfirst(BL::lbl('Date')), 'text' => ucfirst(BL::lbl('Comment'))));
+        // header labels
+        $this->dgSpam->setHeaderLabels(array('created_on' => ucfirst(BL::lbl('Date')), 'text' => ucfirst(BL::lbl('Comment'))));
 
-		// add the multicheckbox column
-		$this->dgSpam->setMassActionCheckboxes('checkbox', '[id]');
+        // add the multicheckbox column
+        $this->dgSpam->setMassActionCheckboxes('checkbox', '[id]');
 
-		// assign column functions
-		$this->dgSpam->setColumnFunction(array(new BackendDataGridFunctions(), 'getTimeAgo'), '[created_on]', 'created_on', true);
-		$this->dgSpam->setColumnFunction(array(new BackendDataGridFunctions(), 'cleanupPlaintext'), '[text]', 'text', true);
-		$this->dgSpam->setColumnFunction(array(__CLASS__, 'addProductData'), array('[text]', '[product_title]', '[product_url]', '[id]'), 'text', true);
+        // assign column functions
+        $this->dgSpam->setColumnFunction(array(new BackendDataGridFunctions(), 'getTimeAgo'), '[created_on]', 'created_on', true);
+        $this->dgSpam->setColumnFunction(array(new BackendDataGridFunctions(), 'cleanupPlaintext'), '[text]', 'text', true);
+        $this->dgSpam->setColumnFunction(array(__CLASS__, 'addProductData'), array('[text]', '[product_title]', '[product_url]', '[id]'), 'text', true);
 
-		// sorting
-		$this->dgSpam->setSortingColumns(array('created_on', 'text', 'author'), 'created_on');
-		$this->dgSpam->setSortParameter('desc');
+        // sorting
+        $this->dgSpam->setSortingColumns(array('created_on', 'text', 'author'), 'created_on');
+        $this->dgSpam->setSortParameter('desc');
 
-		// hide columns
-		$this->dgSpam->setColumnsHidden('product_id', 'product_title', 'product_url');
+        // hide columns
+        $this->dgSpam->setColumnsHidden('product_id', 'product_title', 'product_url');
 
-		// add mass action dropdown
-		$ddmMassAction = new \SpoonFormDropdown('action', array('published' => BL::lbl('MoveToPublished'), 'moderation' => BL::lbl('MoveToModeration'), 'delete' => BL::lbl('Delete')), 'published');
-		$ddmMassAction->setAttribute('id', 'actionSpam');
-		$ddmMassAction->setOptionAttributes('delete', array('data-message-id' => 'confirmDeleteSpam'));
-		$this->dgSpam->setMassAction($ddmMassAction);
+        // add mass action dropdown
+        $ddmMassAction = new \SpoonFormDropdown('action', array('published' => BL::lbl('MoveToPublished'), 'moderation' => BL::lbl('MoveToModeration'), 'delete' => BL::lbl('Delete')), 'published');
+        $ddmMassAction->setAttribute('id', 'actionSpam');
+        $ddmMassAction->setOptionAttributes('delete', array('data-message-id' => 'confirmDeleteSpam'));
+        $this->dgSpam->setMassAction($ddmMassAction);
 
-		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('MassCommentAction')) {
-			$this->dgSpam->addColumn('approve', null, BL::lbl('Approve'), BackendModel::createURLForAction('mass_comment_action') . '&amp;id=[id]&amp;from=spam&amp;action=published', BL::lbl('Approve'));
-		}
-	}
+        // check if this action is allowed
+        if (BackendAuthentication::isAllowedAction('MassCommentAction')) {
+            $this->dgSpam->addColumn('approve', null, BL::lbl('Approve'), BackendModel::createURLForAction('mass_comment_action') . '&amp;id=[id]&amp;from=spam&amp;action=published', BL::lbl('Approve'));
+        }
+    }
 
-	/**
-	 * Parse & display the page
-	 */
-	protected function parse()
-	{
-		parent::parse();
+    /**
+     * Parse & display the page
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-		// published datagrid and num results
-		$this->tpl->assign('dgPublished', ($this->dgPublished->getNumResults() != 0) ? $this->dgPublished->getContent() : false);
-		$this->tpl->assign('numPublished', $this->dgPublished->getNumResults());
+        // published datagrid and num results
+        $this->tpl->assign('dgPublished', ($this->dgPublished->getNumResults() != 0) ? $this->dgPublished->getContent() : false);
+        $this->tpl->assign('numPublished', $this->dgPublished->getNumResults());
 
-		// moderation datagrid and num results
-		$this->tpl->assign('dgModeration', ($this->dgModeration->getNumResults() != 0) ? $this->dgModeration->getContent() : false);
-		$this->tpl->assign('numModeration', $this->dgModeration->getNumResults());
+        // moderation datagrid and num results
+        $this->tpl->assign('dgModeration', ($this->dgModeration->getNumResults() != 0) ? $this->dgModeration->getContent() : false);
+        $this->tpl->assign('numModeration', $this->dgModeration->getNumResults());
 
-		// spam datagrid and num results
-		$this->tpl->assign('dgSpam', ($this->dgSpam->getNumResults() != 0) ? $this->dgSpam->getContent() : false);
-		$this->tpl->assign('numSpam', $this->dgSpam->getNumResults());
-	}
+        // spam datagrid and num results
+        $this->tpl->assign('dgSpam', ($this->dgSpam->getNumResults() != 0) ? $this->dgSpam->getContent() : false);
+        $this->tpl->assign('numSpam', $this->dgSpam->getNumResults());
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/Delete.php
+++ b/src/Backend/Modules/Catalog/Actions/Delete.php
@@ -22,38 +22,39 @@ use Backend\Modules\Search\Engine\Model as BackendSearchModel;
  */
 class Delete extends BackendBaseActionDelete
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{		
-		$this->id = $this->getParameter('id', 'int');
-		
-		// does the item exist
-		if($this->id !== null && BackendCatalogModel::exists($this->id)) {	
-			parent::execute();
-			
-			$this->record = BackendCatalogModel::get($this->id);
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('id', 'int');
+        
+        // does the item exist
+        if ($this->id !== null && BackendCatalogModel::exists($this->id)) {
+            parent::execute();
+            
+            $this->record = BackendCatalogModel::get($this->id);
 
-			// clean the tags
-			BackendTagsModel::saveTags($item['id'], '', $this->URL->getModule());
+            // clean the tags
+            BackendTagsModel::saveTags($item['id'], '', $this->URL->getModule());
 
-			// clean the related products
-			BackendCatalogModel::saveRelatedProducts($item['id'], array());
+            // clean the related products
+            BackendCatalogModel::saveRelatedProducts($item['id'], array());
 
-			// delete record
-			BackendCatalogModel::delete($this->id);
+            // delete record
+            BackendCatalogModel::delete($this->id);
 
-			// delete search indexes
-			BackendSearchModel::removeIndex($this->getModule(), $this->id);
-			
-			BackendModel::triggerEvent(
-				$this->getModule(), 'after_delete',
-				array('id' => $this->id)
-			);
+            // delete search indexes
+            BackendSearchModel::removeIndex($this->getModule(), $this->id);
+            
+            BackendModel::triggerEvent(
+                $this->getModule(), 'after_delete',
+                array('id' => $this->id)
+            );
 
-			$this->redirect(BackendModel::createURLForAction('index') . '&report=deleted&var=' . urlencode($this->record['title']));
-		}
-		else $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
+            $this->redirect(BackendModel::createURLForAction('index') . '&report=deleted&var=' . urlencode($this->record['title']));
+        } else {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/DeleteBrand.php
+++ b/src/Backend/Modules/Catalog/Actions/DeleteBrand.php
@@ -21,29 +21,28 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class DeleteBrand extends BackendBaseActionDelete
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('id', 'int');
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('id', 'int');
 
-		// does the item exist
-		if($this->id == null || !BackendCatalogModel::existsBrand($this->id))
-		{
-			$this->redirect(BackendModel::createURLForAction('brands') . '&error=non-existing');
-		}
+        // does the item exist
+        if ($this->id == null || !BackendCatalogModel::existsBrand($this->id)) {
+            $this->redirect(BackendModel::createURLForAction('brands') . '&error=non-existing');
+        }
 
-		// fetch the brand
-		$this->record = (array)BackendCatalogModel::getBrand($this->id);
+        // fetch the brand
+        $this->record = (array)BackendCatalogModel::getBrand($this->id);
 
-		// delete item
-		BackendCatalogModel::deleteBrand($this->id);
+        // delete item
+        BackendCatalogModel::deleteBrand($this->id);
 
-		// trigger event
-		BackendModel::triggerEvent($this->getModule(), 'after_delete_brand', array('item' => $this->record));
+        // trigger event
+        BackendModel::triggerEvent($this->getModule(), 'after_delete_brand', array('item' => $this->record));
 
-		// brand was deleted, so redirect
-		$this->redirect(BackendModel::createURLForAction('brands') . '&report=deleted-brand&var=' . urlencode($this->record['title']));
-	}
+        // brand was deleted, so redirect
+        $this->redirect(BackendModel::createURLForAction('brands') . '&report=deleted-brand&var=' . urlencode($this->record['title']));
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/DeleteCategory.php
+++ b/src/Backend/Modules/Catalog/Actions/DeleteCategory.php
@@ -21,36 +21,36 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class DeleteCategory extends BackendBaseActionDelete
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('id', 'int');
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('id', 'int');
 
-		// does the item exist
-		if($this->id == null || !BackendCatalogModel::existsCategory($this->id)) {
-			$this->redirect(
-				BackendModel::createURLForAction('categories') . '&error=non-existing'
-			);
-		}
+        // does the item exist
+        if ($this->id == null || !BackendCatalogModel::existsCategory($this->id)) {
+            $this->redirect(
+                BackendModel::createURLForAction('categories') . '&error=non-existing'
+            );
+        }
 
-		// fetch the category
-		$this->record = (array) BackendCatalogModel::getCategory($this->id);
+        // fetch the category
+        $this->record = (array) BackendCatalogModel::getCategory($this->id);
 
-		// delete item
-		BackendCatalogModel::deleteCategory($this->id);
-		
-		// trigger event
-		BackendModel::triggerEvent(
-			$this->getModule(),
-			'after_delete_category',
-			array('item' => $this->record)
-		);
+        // delete item
+        BackendCatalogModel::deleteCategory($this->id);
+        
+        // trigger event
+        BackendModel::triggerEvent(
+            $this->getModule(),
+            'after_delete_category',
+            array('item' => $this->record)
+        );
 
-		// category was deleted, so redirect
-		$this->redirect(
-			BackendModel::createURLForAction('categories') . '&report=deleted-category&var=' . urlencode($this->record['title'])
-		);
-	}
+        // category was deleted, so redirect
+        $this->redirect(
+            BackendModel::createURLForAction('categories') . '&report=deleted-category&var=' . urlencode($this->record['title'])
+        );
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/DeleteCompleted.php
+++ b/src/Backend/Modules/Catalog/Actions/DeleteCompleted.php
@@ -21,15 +21,15 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class DeleteCompleted extends BackendBaseActionDelete
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
-		BackendCatalogModel::deleteCompletedOrders();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
+        BackendCatalogModel::deleteCompletedOrders();
 
-		// item was deleted, so redirect
-		$this->redirect(BackendModel::createURLForAction('orders') . '&report=deleted-completed#tabCompleted');
-	}
+        // item was deleted, so redirect
+        $this->redirect(BackendModel::createURLForAction('orders') . '&report=deleted-completed#tabCompleted');
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/DeleteSpam.php
+++ b/src/Backend/Modules/Catalog/Actions/DeleteSpam.php
@@ -21,15 +21,15 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class DeleteSpam extends BackendBaseActionDelete
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
-		BackendCatalogModel::deleteSpamComments();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
+        BackendCatalogModel::deleteSpamComments();
 
-		// item was deleted, so redirect
-		$this->redirect(BackendModel::createURLForAction('comments') . '&report=deleted-spam#tabSpam');
-	}
+        // item was deleted, so redirect
+        $this->redirect(BackendModel::createURLForAction('comments') . '&report=deleted-spam#tabSpam');
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/DeleteSpecification.php
+++ b/src/Backend/Modules/Catalog/Actions/DeleteSpecification.php
@@ -21,32 +21,32 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class DeleteSpecification extends BackendBaseActionDelete
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('id', 'int');
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('id', 'int');
 
-		// does the item exist
-		if($this->id == null || !BackendCatalogModel::existsSpecification($this->id)) {
-			$this->redirect(
-				BackendModel::createURLForAction('specifications') . '&error=non-existing'
-			);
-		}
+        // does the item exist
+        if ($this->id == null || !BackendCatalogModel::existsSpecification($this->id)) {
+            $this->redirect(
+                BackendModel::createURLForAction('specifications') . '&error=non-existing'
+            );
+        }
 
-		// fetch the specification
-		$this->record = (array) BackendCatalogModel::getSpecification($this->id);
+        // fetch the specification
+        $this->record = (array) BackendCatalogModel::getSpecification($this->id);
 
-		// delete item
-		BackendCatalogModel::deleteSpecification($this->id);
-		
-		// trigger event
-		BackendModel::triggerEvent($this->getModule(), 'after_delete_specification', array('item' => $this->record));
+        // delete item
+        BackendCatalogModel::deleteSpecification($this->id);
+        
+        // trigger event
+        BackendModel::triggerEvent($this->getModule(), 'after_delete_specification', array('item' => $this->record));
 
-		// specification was deleted, so redirect
-		$this->redirect(
-			BackendModel::createURLForAction('specifications') . '&report=deleted-specification&var=' . urlencode($this->record['title'])
-		);
-	}
+        // specification was deleted, so redirect
+        $this->redirect(
+            BackendModel::createURLForAction('specifications') . '&report=deleted-specification&var=' . urlencode($this->record['title'])
+        );
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/Edit.php
+++ b/src/Backend/Modules/Catalog/Actions/Edit.php
@@ -31,235 +31,239 @@ use Backend\Modules\Users\Engine\Model as BackendUsersModel;
  */
 class Edit extends BackendBaseActionEdit
 {
-	/**
-	 * All categories
-	 *
-	 * @var	array
-	 */
-	private $categories;
+    /**
+     * All categories
+     *
+     * @var	array
+     */
+    private $categories;
 
-	/**
-	 * Products grouped by categories
-	 *
-	 * @var	array
-	 */
-	private $allProductsGroupedByCategories;
+    /**
+     * Products grouped by categories
+     *
+     * @var	array
+     */
+    private $allProductsGroupedByCategories;
 
-	/**
-	 * All specifications
-	 *
-	 * @var	array
-	 */
-	private $specifications;
+    /**
+     * All specifications
+     *
+     * @var	array
+     */
+    private $specifications;
 
-	/**
-	 * All products
-	 *
-	 * @var	array
-	 */
-	private $products;
+    /**
+     * All products
+     *
+     * @var	array
+     */
+    private $products;
 
-	/**
-	 * All related products
-	 *
-	 * @var	array
-	 */
-	private $relatedProducts;
+    /**
+     * All related products
+     *
+     * @var	array
+     */
+    private $relatedProducts;
 
-	/**
-	 * All brands
-	 *
-	 * @var	array
-	 */
-	private $brands;
+    /**
+     * All brands
+     *
+     * @var	array
+     */
+    private $brands;
 
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
-	
-		$this->loadData();
-		$this->loadForm();
-		
-		$this->validateForm();
-	
-		$this->parse();
-		$this->display();
-	}
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
+    
+        $this->loadData();
+        $this->loadForm();
+        
+        $this->validateForm();
+    
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Load the item data
-	 */
-	protected function loadData()
-	{
-		$this->id = $this->getParameter('id', 'int', null);
-		
-		if($this->id == null || !BackendCatalogModel::exists($this->id)) {
-			$this->redirect(
-				BackendModel::createURLForAction('index') . '&error=non-existing'
-			);
-		}
+    /**
+     * Load the item data
+     */
+    protected function loadData()
+    {
+        $this->id = $this->getParameter('id', 'int', null);
+        
+        if ($this->id == null || !BackendCatalogModel::exists($this->id)) {
+            $this->redirect(
+                BackendModel::createURLForAction('index') . '&error=non-existing'
+            );
+        }
 
-		$this->record = BackendCatalogModel::get($this->id);
-		
-		$this->categories = (array) BackendCatalogModel::getCategories(true);
-		$this->products = (array) BackendCatalogModel::getAll();
-		$this->allProductsGroupedByCategories = (array) BackendCatalogModel::getAllProductsGroupedByCategories();
-		$this->relatedProducts = (array) BackendCatalogModel::getRelatedProducts($this->id);
-		$this->specifications = (array) BackendCatalogModel::getSpecifications();
+        $this->record = BackendCatalogModel::get($this->id);
+        
+        $this->categories = (array) BackendCatalogModel::getCategories(true);
+        $this->products = (array) BackendCatalogModel::getAll();
+        $this->allProductsGroupedByCategories = (array) BackendCatalogModel::getAllProductsGroupedByCategories();
+        $this->relatedProducts = (array) BackendCatalogModel::getRelatedProducts($this->id);
+        $this->specifications = (array) BackendCatalogModel::getSpecifications();
 
-		// get brands
-		$this->brands = BackendCatalogModel::getBrandsForDropdown();
-	}
+        // get brands
+        $this->brands = BackendCatalogModel::getBrandsForDropdown();
+    }
 
-	/**
-	 * Load the form
-	 */
-	protected function loadForm()
-	{
-		// create form
-		$this->frm = new BackendForm('edit');
+    /**
+     * Load the form
+     */
+    protected function loadForm()
+    {
+        // create form
+        $this->frm = new BackendForm('edit');
 
-		$this->frm->addText('title' ,$this->record['title'], null, 'inputText title', 'inputTextError title');
-		$this->frm->addEditor('summary', $this->record['summary']);
-		$this->frm->addEditor('text', $this->record['text']);
-		$this->frm->addText('price' ,$this->record['price'], null, 'inputText price', 'inputTextError price');
-		$this->frm->addText('tags', BackendTagsModel::getTags($this->URL->getModule(), $this->record['id']), null, 'inputText tagBox', 'inputTextError tagBox');
-		$this->frm->addDropdown('related_products', $this->allProductsGroupedByCategories, $this->relatedProducts, true );
+        $this->frm->addText('title', $this->record['title'], null, 'inputText title', 'inputTextError title');
+        $this->frm->addEditor('summary', $this->record['summary']);
+        $this->frm->addEditor('text', $this->record['text']);
+        $this->frm->addText('price', $this->record['price'], null, 'inputText price', 'inputTextError price');
+        $this->frm->addText('tags', BackendTagsModel::getTags($this->URL->getModule(), $this->record['id']), null, 'inputText tagBox', 'inputTextError tagBox');
+        $this->frm->addDropdown('related_products', $this->allProductsGroupedByCategories, $this->relatedProducts, true);
         $this->frm->addCheckbox('allow_comments', ($this->record['allow_comments'] === 'Y' ? true : false));
 
         // categories
-		$this->frm->addDropdown('category_id', $this->categories, $this->record['category_id']);
+        $this->frm->addDropdown('category_id', $this->categories, $this->record['category_id']);
 
-		$this->frm->addDropdown('brand_id', $this->brands, $this->record['brand_id']);
+        $this->frm->addDropdown('brand_id', $this->brands, $this->record['brand_id']);
 
-		$specificationsHTML = array();
-		
-		// specifications
-		foreach($this->specifications as $specification) {
-			$specificationName = 'specification' . $specification['id'];
-			
-			$value = BackendCatalogModel::getSpecificationValue($specification['id'], $this->record['id']);
-			
-			// check if value is set
-			$value = (isset($value['value']) ? $value['value'] : null);
-									
-			// @todo check if type is text or textarea..
-			$specificationText = $this->frm->addText($specificationName, $value);
-			$specificationHTML = $specificationText->parse();
-			
-			// parse specification into template
-			$this->tpl->assign('id', $specification['id']);
-			$this->tpl->assign('label', $specification['title']);
-			$this->tpl->assign('field', $specificationHTML);
-			$this->tpl->assign('spec', true);
-			
-			$specificationsHTML[]['specification'] = $this->tpl->getContent(BACKEND_MODULE_PATH . '/Layout/Templates/Specification.tpl');
-		}
-		
-		$this->tpl->assign('specifications', $specificationsHTML);
-		
-		// meta object
-		$this->meta = new BackendMeta($this->frm, $this->record['meta_id'], 'title', true);
-		
-		// set callback for generating a unique URL
-		$this->meta->setUrlCallback('Backend\Modules\Catalog\Engine\Model', 'getURL', array($this->record['id']));
-	}
+        $specificationsHTML = array();
+        
+        // specifications
+        foreach ($this->specifications as $specification) {
+            $specificationName = 'specification' . $specification['id'];
+            
+            $value = BackendCatalogModel::getSpecificationValue($specification['id'], $this->record['id']);
+            
+            // check if value is set
+            $value = (isset($value['value']) ? $value['value'] : null);
+                                    
+            // @todo check if type is text or textarea..
+            $specificationText = $this->frm->addText($specificationName, $value);
+            $specificationHTML = $specificationText->parse();
+            
+            // parse specification into template
+            $this->tpl->assign('id', $specification['id']);
+            $this->tpl->assign('label', $specification['title']);
+            $this->tpl->assign('field', $specificationHTML);
+            $this->tpl->assign('spec', true);
+            
+            $specificationsHTML[]['specification'] = $this->tpl->getContent(BACKEND_MODULE_PATH . '/Layout/Templates/Specification.tpl');
+        }
+        
+        $this->tpl->assign('specifications', $specificationsHTML);
+        
+        // meta object
+        $this->meta = new BackendMeta($this->frm, $this->record['meta_id'], 'title', true);
+        
+        // set callback for generating a unique URL
+        $this->meta->setUrlCallback('Backend\Modules\Catalog\Engine\Model', 'getURL', array($this->record['id']));
+    }
 
-	/**
-	 * Parse the page
-	 */
-	protected function parse()
-	{
-		parent::parse();
+    /**
+     * Parse the page
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-		// get url
-		$url = BackendModel::getURLForBlock($this->URL->getModule(), 'detail');
-		$url404 = BackendModel::getURL(404);
+        // get url
+        $url = BackendModel::getURLForBlock($this->URL->getModule(), 'detail');
+        $url404 = BackendModel::getURL(404);
 
-		// parse additional variables
-		if($url404 != $url) $this->tpl->assign('detailURL', SITE_URL . $url);
+        // parse additional variables
+        if ($url404 != $url) {
+            $this->tpl->assign('detailURL', SITE_URL . $url);
+        }
 
-		$this->tpl->assign('product', $this->record);
-	}
+        $this->tpl->assign('product', $this->record);
+    }
 
-	/**
-	 * Validate the form
-	 */
-	protected function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    protected function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            $this->frm->cleanupFields();
 
-			// validation
-			$fields = $this->frm->getFields();
+            // validation
+            $fields = $this->frm->getFields();
 
-			$fields['title']->isFilled(BL::err('FieldIsRequired'));
-			$fields['summary']->isFilled(BL::err('FieldIsRequired'));
-			$fields['category_id']->isFilled(BL::err('FieldIsRequired'));
-			if($fields['category_id']->getValue() == 'no_category') $fields['category_id']->addError(BL::err('FieldIsRequired'));
+            $fields['title']->isFilled(BL::err('FieldIsRequired'));
+            $fields['summary']->isFilled(BL::err('FieldIsRequired'));
+            $fields['category_id']->isFilled(BL::err('FieldIsRequired'));
+            if ($fields['category_id']->getValue() == 'no_category') {
+                $fields['category_id']->addError(BL::err('FieldIsRequired'));
+            }
 
-			// validate meta
-			$this->meta->validate();
+            // validate meta
+            $this->meta->validate();
 
-			if($this->frm->isCorrect()) {
-				$item['id'] = $this->id;
-				$item['language'] = BL::getWorkingLanguage();
-				$item['price'] = $fields['price']->getValue();
-				$item['title'] = $fields['title']->getValue();
-				$item['summary'] = $fields['summary']->getValue();
-				$item['text'] = $fields['text']->getValue();
-				$item['category_id'] = $this->frm->getField('category_id')->getValue();
-				$item['brand_id'] = $fields['brand_id']->getValue();
+            if ($this->frm->isCorrect()) {
+                $item['id'] = $this->id;
+                $item['language'] = BL::getWorkingLanguage();
+                $item['price'] = $fields['price']->getValue();
+                $item['title'] = $fields['title']->getValue();
+                $item['summary'] = $fields['summary']->getValue();
+                $item['text'] = $fields['text']->getValue();
+                $item['category_id'] = $this->frm->getField('category_id')->getValue();
+                $item['brand_id'] = $fields['brand_id']->getValue();
                 $item['allow_comments'] = $this->frm->getField('allow_comments')->getChecked() ? 'Y' : 'N';
 
-				$item['meta_id'] = $this->meta->save();
+                $item['meta_id'] = $this->meta->save();
 
-				BackendCatalogModel::update($item);
-				$item['id'] = $this->id;
-				$specificationArray = array();
-				
-				// loop trough specifications and insert values
-				foreach( $this->specifications as $specification) {
-					$field = 'specification' . $specification['id'];
-					
-					// check if there is an value
-					if($fields[$field]->getValue() != null) { 
-						$specificationArray['value'] = $fields[$field]->getValue();
-						$specificationArray['product_id'] = $item['id'];
-						$specificationArray['specification_id'] = $specification['id'];
-						
-						// when specification value already exists. update value
-						if(BackendCatalogModel::existsSpecificationValue($item['id'], $specification['id']) != false) {
-							// update specification with product id and value
-							BackendCatalogModel::updateSpecificationValue($specification['id'], $item['id'], $specificationArray);
-						} else {							
-							// when specification value doesnt exists, insert new value
-							BackendCatalogModel::insertSpecificationValue($specificationArray);
-						}
-					}
-				}
-				
-				// save the tags
-				BackendTagsModel::saveTags($item['id'], $fields['tags']->getValue(), $this->URL->getModule());
+                BackendCatalogModel::update($item);
+                $item['id'] = $this->id;
+                $specificationArray = array();
+                
+                // loop trough specifications and insert values
+                foreach ($this->specifications as $specification) {
+                    $field = 'specification' . $specification['id'];
+                    
+                    // check if there is an value
+                    if ($fields[$field]->getValue() != null) {
+                        $specificationArray['value'] = $fields[$field]->getValue();
+                        $specificationArray['product_id'] = $item['id'];
+                        $specificationArray['specification_id'] = $specification['id'];
+                        
+                        // when specification value already exists. update value
+                        if (BackendCatalogModel::existsSpecificationValue($item['id'], $specification['id']) != false) {
+                            // update specification with product id and value
+                            BackendCatalogModel::updateSpecificationValue($specification['id'], $item['id'], $specificationArray);
+                        } else {
+                            // when specification value doesnt exists, insert new value
+                            BackendCatalogModel::insertSpecificationValue($specificationArray);
+                        }
+                    }
+                }
+                
+                // save the tags
+                BackendTagsModel::saveTags($item['id'], $fields['tags']->getValue(), $this->URL->getModule());
 
-				// add search index
-				BackendSearchModel::saveIndex($this->getModule(), $item['id'], array('title' => $item['title'], 'summary' => $item['summary'], 'text' => $item['text']));
+                // add search index
+                BackendSearchModel::saveIndex($this->getModule(), $item['id'], array('title' => $item['title'], 'summary' => $item['summary'], 'text' => $item['text']));
 
-				// save related projects
-				BackendCatalogModel::saveRelatedProducts($item['id'], $this->frm->getField('related_products')->getValue(), $this->relatedProducts);
-				
-				// trigger event
-				BackendModel::triggerEvent(
-					$this->getModule(), 'after_edit', $item
-				);
-				
-				$this->redirect(
-					BackendModel::createURLForAction('index') . '&report=edited&highlight=row-' . $item['id']
-				);
-			}
-		}
-	}
+                // save related projects
+                BackendCatalogModel::saveRelatedProducts($item['id'], $this->frm->getField('related_products')->getValue(), $this->relatedProducts);
+                
+                // trigger event
+                BackendModel::triggerEvent(
+                    $this->getModule(), 'after_edit', $item
+                );
+                
+                $this->redirect(
+                    BackendModel::createURLForAction('index') . '&report=edited&highlight=row-' . $item['id']
+                );
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/EditBrand.php
+++ b/src/Backend/Modules/Catalog/Actions/EditBrand.php
@@ -28,104 +28,100 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class EditBrand extends BackendBaseActionEdit
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
 
-		parent::execute();
-
-		$this->getData();
-		$this->loadForm();
-		$this->validateForm();
+        $this->getData();
+        $this->loadForm();
+        $this->validateForm();
 
 
-		$this->parse();
-		$this->display();
-	}
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Get the data
-	 */
-	private function getData()
-	{
-		$this->id = $this->getParameter('id', 'int');
-		if($this->id == null || !BackendCatalogModel::existsBrand($this->id))
-		{
-			$this->redirect(BackendModel::createURLForAction('brands') . '&error=non-existing');
-		}
+    /**
+     * Get the data
+     */
+    private function getData()
+    {
+        $this->id = $this->getParameter('id', 'int');
+        if ($this->id == null || !BackendCatalogModel::existsBrand($this->id)) {
+            $this->redirect(BackendModel::createURLForAction('brands') . '&error=non-existing');
+        }
 
-		$this->record = BackendCatalogModel::getBrand($this->id);
-	}
+        $this->record = BackendCatalogModel::getBrand($this->id);
+    }
 
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		// create form
-		$this->frm = new BackendForm('editBrand');
-		$this->frm->addText('title', $this->record['title']);
-		$this->frm->addImage('image');
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        // create form
+        $this->frm = new BackendForm('editBrand');
+        $this->frm->addText('title', $this->record['title']);
+        $this->frm->addImage('image');
         $this->frm->addCheckbox('delete_image');
 
         $this->meta = new BackendMeta($this->frm, $this->record['meta_id'], 'title', true);
-		$this->meta->setUrlCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForBrand', array($this->record['id']));
-	}
+        $this->meta->setUrlCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForBrand', array($this->record['id']));
+    }
 
-	/**
-	 * Parse the form
-	 */
-	protected function parse()
-	{
-		parent::parse();
+    /**
+     * Parse the form
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-		// assign the data
-		$this->tpl->assign('item', $this->record);
+        // assign the data
+        $this->tpl->assign('item', $this->record);
 
-		// is brand allowed to be deleted?
-		if(BackendCatalogModel::isBrandAllowedToBeDeleted($this->id)) $this->tpl->assign('showDelete', true);
-	}
+        // is brand allowed to be deleted?
+        if (BackendCatalogModel::isBrandAllowedToBeDeleted($this->id)) {
+            $this->tpl->assign('showDelete', true);
+        }
+    }
 
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted())
-		{
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            $this->frm->cleanupFields();
 
-			// validate fields
-			$this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
+            // validate fields
+            $this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
 
-			if($this->frm->getField('image')->isFilled())
-			{
-				$this->frm->getField('image')->isAllowedExtension(array('jpg', 'png', 'gif', 'jpeg'), BL::err('JPGGIFAndPNGOnly'));
-				$this->frm->getField('image')->isAllowedMimeType(array('image/jpg', 'image/png', 'image/gif', 'image/jpeg'), BL::err('JPGGIFAndPNGOnly'));
-			}
+            if ($this->frm->getField('image')->isFilled()) {
+                $this->frm->getField('image')->isAllowedExtension(array('jpg', 'png', 'gif', 'jpeg'), BL::err('JPGGIFAndPNGOnly'));
+                $this->frm->getField('image')->isAllowedMimeType(array('image/jpg', 'image/png', 'image/gif', 'image/jpeg'), BL::err('JPGGIFAndPNGOnly'));
+            }
 
-			$this->meta->validate();
+            $this->meta->validate();
 
-			if($this->frm->isCorrect())
-			{
-				// build item
-				$item['id'] = $this->id;
-				$item['title'] = $this->frm->getField('title')->getValue();
-				$item['meta_id'] = $this->meta->save(true);
+            if ($this->frm->isCorrect()) {
+                // build item
+                $item['id'] = $this->id;
+                $item['title'] = $this->frm->getField('title')->getValue();
+                $item['meta_id'] = $this->meta->save(true);
 
-				// the image path
-				$imagePath = FRONTEND_FILES_PATH . '/catalog/brands';
+                // the image path
+                $imagePath = FRONTEND_FILES_PATH . '/catalog/brands';
 
-				// create folders if needed
-				$fs = new Filesystem();
+                // create folders if needed
+                $fs = new Filesystem();
 
-				if(!$fs->exists($imagePath . '/source/'))
-				{
-					$fs->mkdir($imagePath . '/source/');
+                if (!$fs->exists($imagePath . '/source/')) {
+                    $fs->mkdir($imagePath . '/source/');
                     $fs->mkdir($imagePath . '/150x150/');
-				}
+                }
 
                 if ($this->frm->getField('delete_image')->isChecked()) {
                     BackendModel::deleteThumbnails($imagePath, $this->record['image']);
@@ -133,26 +129,25 @@ class EditBrand extends BackendBaseActionEdit
                 }
 
                 // image provided?
-				if($this->frm->getField('image')->isFilled())
-				{
+                if ($this->frm->getField('image')->isFilled()) {
                     BackendModel::deleteThumbnails($imagePath, $this->record['image']);
 
-					// build the image name
-					$item['image'] = $this->meta->getUrl() . '.' . $this->frm->getField('image')->getExtension();
+                    // build the image name
+                    $item['image'] = $this->meta->getUrl() . '.' . $this->frm->getField('image')->getExtension();
 
-					// upload the image & generate thumbnails
-					$this->frm->getField('image')->generateThumbnails($imagePath, $item['image']);
-				}
+                    // upload the image & generate thumbnails
+                    $this->frm->getField('image')->generateThumbnails($imagePath, $item['image']);
+                }
 
-				// update the item
-				BackendCatalogModel::updateBrand($item);
+                // update the item
+                BackendCatalogModel::updateBrand($item);
 
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_edit_brand', array('item' => $item));
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_edit_brand', array('item' => $item));
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(BackendModel::createURLForAction('brands') . '&report=edited-brand&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']);
-			}
-		}
-	}
+                // everything is saved, so redirect to the overview
+                $this->redirect(BackendModel::createURLForAction('brands') . '&report=edited-brand&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']);
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/EditCategory.php
+++ b/src/Backend/Modules/Catalog/Actions/EditCategory.php
@@ -27,146 +27,148 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class EditCategory extends BackendBaseActionEdit
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
 
-		$this->getData();
-		$this->loadForm();
-		$this->validateForm();
+        $this->getData();
+        $this->loadForm();
+        $this->validateForm();
 
-		$this->parse();
-		$this->display();
-	}
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Get the data
-	 */
-	private function getData()
-	{
-		$this->id = $this->getParameter('id', 'int');
-		if($this->id == null || !BackendCatalogModel::existsCategory($this->id)) {
-			$this->redirect(
-				BackendModel::createURLForAction('categories') . '&error=non-existing'
-			);
-		}
+    /**
+     * Get the data
+     */
+    private function getData()
+    {
+        $this->id = $this->getParameter('id', 'int');
+        if ($this->id == null || !BackendCatalogModel::existsCategory($this->id)) {
+            $this->redirect(
+                BackendModel::createURLForAction('categories') . '&error=non-existing'
+            );
+        }
 
-		$this->record = BackendCatalogModel::getCategory($this->id);
-	}
+        $this->record = BackendCatalogModel::getCategory($this->id);
+    }
 
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		// create form
-		$this->frm = new BackendForm('editCategory');
-		$this->frm->addText('title', $this->record['title']);
-		$this->frm->addImage('image');
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        // create form
+        $this->frm = new BackendForm('editCategory');
+        $this->frm->addText('title', $this->record['title']);
+        $this->frm->addImage('image');
         $this->frm->addCheckbox('delete_image');
 
-		//hidden values
-		$categories = BackendCatalogModel::getCategories(true);
-		
-		$this->frm->addDropdown('parent_id', $categories, $this->record['parent_id']);
+        //hidden values
+        $categories = BackendCatalogModel::getCategories(true);
+        
+        $this->frm->addDropdown('parent_id', $categories, $this->record['parent_id']);
 
-		$this->meta = new BackendMeta($this->frm, $this->record['meta_id'], 'title', true);
-		$this->meta->setUrlCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForCategory', array($this->record['id']));
-	}
+        $this->meta = new BackendMeta($this->frm, $this->record['meta_id'], 'title', true);
+        $this->meta->setUrlCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForCategory', array($this->record['id']));
+    }
 
-	/**
-	 * Parse the form
-	 */
-	protected function parse()
-	{
-		parent::parse();
+    /**
+     * Parse the form
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-		// assign the data
-		$this->tpl->assign('item', $this->record);
-		
-		// is category allowed to be deleted?
-		if(BackendCatalogModel::isCategoryAllowedToBeDeleted($this->id)) $this->tpl->assign('showDelete', true);
-	}
+        // assign the data
+        $this->tpl->assign('item', $this->record);
+        
+        // is category allowed to be deleted?
+        if (BackendCatalogModel::isCategoryAllowedToBeDeleted($this->id)) {
+            $this->tpl->assign('showDelete', true);
+        }
+    }
 
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            $this->frm->cleanupFields();
 
-			$recordId = $this->record['id'];
-			$newParent = $this->frm->getField('parent_id')->getValue();
-			
-			if($recordId == $newParent) {
-				$this->frm->getField('parent_id')->setError(BL::err('SameCategory'));
-			}
-			
-			// validate fields
-			$this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
-			
-			if($this->frm->getField('image')->isFilled()) {
-				$this->frm->getField('image')->isAllowedExtension(array('jpg', 'png', 'gif', 'jpeg'), BL::err('JPGGIFAndPNGOnly'));
-				$this->frm->getField('image')->isAllowedMimeType(array('image/jpg', 'image/png', 'image/gif', 'image/jpeg'), BL::err('JPGGIFAndPNGOnly'));
-			}
-			
-			$this->meta->validate();
-			
-			if($this->frm->isCorrect()) {
-				// build item
-				$item['id'] = $this->id;
-				$item['language'] = $this->record['language'];
-				$item['title'] = $this->frm->getField('title')->getValue();
-				$item['parent_id'] = $this->frm->getField('parent_id')->getValue();				
-				$item['meta_id'] = $this->meta->save(true);
+            $recordId = $this->record['id'];
+            $newParent = $this->frm->getField('parent_id')->getValue();
+            
+            if ($recordId == $newParent) {
+                $this->frm->getField('parent_id')->setError(BL::err('SameCategory'));
+            }
+            
+            // validate fields
+            $this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
+            
+            if ($this->frm->getField('image')->isFilled()) {
+                $this->frm->getField('image')->isAllowedExtension(array('jpg', 'png', 'gif', 'jpeg'), BL::err('JPGGIFAndPNGOnly'));
+                $this->frm->getField('image')->isAllowedMimeType(array('image/jpg', 'image/png', 'image/gif', 'image/jpeg'), BL::err('JPGGIFAndPNGOnly'));
+            }
+            
+            $this->meta->validate();
+            
+            if ($this->frm->isCorrect()) {
+                // build item
+                $item['id'] = $this->id;
+                $item['language'] = $this->record['language'];
+                $item['title'] = $this->frm->getField('title')->getValue();
+                $item['parent_id'] = $this->frm->getField('parent_id')->getValue();
+                $item['meta_id'] = $this->meta->save(true);
 
-				// the image path
-				$imagePath = FRONTEND_FILES_PATH . '/' . $this->getModule() . '/categories/' . $this->id;
-				
-				// create folders if needed
-				$fs = new Filesystem();
-				
-				if (!$fs->exists($imagePath . '/150x150/')) {
-				    $fs->mkdir($imagePath . '/150x150/');
-				}
-				
-				if (!$fs->exists($imagePath . '/source/')) {
-				    $fs->mkdir($imagePath . '/source/');
-				}
+                // the image path
+                $imagePath = FRONTEND_FILES_PATH . '/' . $this->getModule() . '/categories/' . $this->id;
+                
+                // create folders if needed
+                $fs = new Filesystem();
+                
+                if (!$fs->exists($imagePath . '/150x150/')) {
+                    $fs->mkdir($imagePath . '/150x150/');
+                }
+                
+                if (!$fs->exists($imagePath . '/source/')) {
+                    $fs->mkdir($imagePath . '/source/');
+                }
 
                 if ($this->frm->getField('delete_image')->isChecked()) {
                     BackendModel::deleteThumbnails($imagePath, $this->record['image']);
                     $item['image'] = null;
                 }
-				
-				// image provided?
-				if($this->frm->getField('image')->isFilled()) {
-					// build the image name
-					$item['image'] = $this->meta->getUrl() . '.' . $this->frm->getField('image')->getExtension();
+                
+                // image provided?
+                if ($this->frm->getField('image')->isFilled()) {
+                    // build the image name
+                    $item['image'] = $this->meta->getUrl() . '.' . $this->frm->getField('image')->getExtension();
 
-					// upload the image & generate thumbnails
-					$this->frm->getField('image')->generateThumbnails($imagePath, $item['image']);
-				}
-				
-				// update the item
-				BackendCatalogModel::updateCategory($item);
-				
-				// trigger event
-				BackendModel::triggerEvent(
-					$this->getModule(),
-					'after_edit_category',
-					array('item' => $item)
-				);
+                    // upload the image & generate thumbnails
+                    $this->frm->getField('image')->generateThumbnails($imagePath, $item['image']);
+                }
+                
+                // update the item
+                BackendCatalogModel::updateCategory($item);
+                
+                // trigger event
+                BackendModel::triggerEvent(
+                    $this->getModule(),
+                    'after_edit_category',
+                    array('item' => $item)
+                );
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(
-					BackendModel::createURLForAction('categories') . '&report=edited-category&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']
-				);
-			}
-		}
-	}
+                // everything is saved, so redirect to the overview
+                $this->redirect(
+                    BackendModel::createURLForAction('categories') . '&report=edited-category&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']
+                );
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/EditComment.php
+++ b/src/Backend/Modules/Catalog/Actions/EditComment.php
@@ -23,93 +23,99 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class EditComment extends BackendBaseActionEdit
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('id', 'int');
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('id', 'int');
 
-		// does the item exist
-		if($this->id !== null && BackendCatalogModel::existsComment($this->id)) {
-			parent::execute();
-			$this->getData();
-			$this->loadForm();
-			$this->validateForm();
-			$this->parse();
-			$this->display();
-		}
+        // does the item exist
+        if ($this->id !== null && BackendCatalogModel::existsComment($this->id)) {
+            parent::execute();
+            $this->getData();
+            $this->loadForm();
+            $this->validateForm();
+            $this->parse();
+            $this->display();
+        }
 
-		// no item found, throw an exception, because somebody is fucking with our URL
-		else $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
+        // no item found, throw an exception, because somebody is fucking with our URL
+        else {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 
-	/**
-	 * Get the data
-	 * If a revision-id was specified in the URL we load the revision and not the actual data.
-	 */
-	private function getData()
-	{
-		// get the record
-		$this->record = (array) BackendCatalogModel::getComment($this->id);
+    /**
+     * Get the data
+     * If a revision-id was specified in the URL we load the revision and not the actual data.
+     */
+    private function getData()
+    {
+        // get the record
+        $this->record = (array) BackendCatalogModel::getComment($this->id);
 
-		// no item found, throw an exceptions, because somebody is fucking with our URL
-		if(empty($this->record)) $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
+        // no item found, throw an exceptions, because somebody is fucking with our URL
+        if (empty($this->record)) {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		// create form
-		$this->frm = new BackendForm('editComment');
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        // create form
+        $this->frm = new BackendForm('editComment');
 
-		// create elements
-		$this->frm->addText('author', $this->record['author']);
-		$this->frm->addText('email', $this->record['email']);
-		$this->frm->addText('website', $this->record['website'], null);
-		$this->frm->addTextarea('text', $this->record['text']);
+        // create elements
+        $this->frm->addText('author', $this->record['author']);
+        $this->frm->addText('email', $this->record['email']);
+        $this->frm->addText('website', $this->record['website'], null);
+        $this->frm->addTextarea('text', $this->record['text']);
 
-		// assign URL
-		$this->tpl->assign('itemURL', BackendModel::getURLForBlock($this->getModule(), 'detail') . '/' . $this->record['product_url'] . '#comment-' . $this->record['product_id']);
-		$this->tpl->assign('itemTitle', $this->record['product_title']);
-	}
+        // assign URL
+        $this->tpl->assign('itemURL', BackendModel::getURLForBlock($this->getModule(), 'detail') . '/' . $this->record['product_url'] . '#comment-' . $this->record['product_id']);
+        $this->tpl->assign('itemTitle', $this->record['product_title']);
+    }
 
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			// cleanup the submitted fields, ignore fields that were added by hackers
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            // cleanup the submitted fields, ignore fields that were added by hackers
+            $this->frm->cleanupFields();
 
-			// validate fields
-			$this->frm->getField('author')->isFilled(BL::err('AuthorIsRequired'));
-			$this->frm->getField('email')->isEmail(BL::err('EmailIsInvalid'));
-			$this->frm->getField('text')->isFilled(BL::err('FieldIsRequired'));
-			if($this->frm->getField('website')->isFilled()) $this->frm->getField('website')->isURL(BL::err('InvalidURL'));
+            // validate fields
+            $this->frm->getField('author')->isFilled(BL::err('AuthorIsRequired'));
+            $this->frm->getField('email')->isEmail(BL::err('EmailIsInvalid'));
+            $this->frm->getField('text')->isFilled(BL::err('FieldIsRequired'));
+            if ($this->frm->getField('website')->isFilled()) {
+                $this->frm->getField('website')->isURL(BL::err('InvalidURL'));
+            }
 
-			// no errors?
-			if($this->frm->isCorrect()) {
-				// build item
-				$item['id'] = $this->id;
-				$item['status'] = $this->record['status'];
-				$item['author'] = $this->frm->getField('author')->getValue();
-				$item['email'] = $this->frm->getField('email')->getValue();
-				$item['website'] = ($this->frm->getField('website')->isFilled()) ? $this->frm->getField('website')->getValue() : null;
-				$item['text'] = $this->frm->getField('text')->getValue();
+            // no errors?
+            if ($this->frm->isCorrect()) {
+                // build item
+                $item['id'] = $this->id;
+                $item['status'] = $this->record['status'];
+                $item['author'] = $this->frm->getField('author')->getValue();
+                $item['email'] = $this->frm->getField('email')->getValue();
+                $item['website'] = ($this->frm->getField('website')->isFilled()) ? $this->frm->getField('website')->getValue() : null;
+                $item['text'] = $this->frm->getField('text')->getValue();
 
-				// insert the item
-				BackendCatalogModel::updateComment($item);
+                // insert the item
+                BackendCatalogModel::updateComment($item);
 
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_edit_comment', array('item' => $item));
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_edit_comment', array('item' => $item));
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(BackendModel::createURLForAction('comments') . '&report=edited-comment&id=' . $item['id'] . '&highlight=row-' . $item['id'] . '#tab' . ucwords($item['status']));
-			}
-		}
-	}
+                // everything is saved, so redirect to the overview
+                $this->redirect(BackendModel::createURLForAction('comments') . '&report=edited-comment&id=' . $item['id'] . '&highlight=row-' . $item['id'] . '#tab' . ucwords($item['status']));
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/EditFile.php
+++ b/src/Backend/Modules/Catalog/Actions/EditFile.php
@@ -45,106 +45,109 @@ class EditFile extends BackendBaseActionEdit
     private $file;
 
     /**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('id', 'int');
-		
-		if($this->id !== null && BackendCatalogModel::existsFile($this->id)) {
-			parent::execute();
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('id', 'int');
+        
+        if ($this->id !== null && BackendCatalogModel::existsFile($this->id)) {
+            parent::execute();
 
-			$this->getData();
-			$this->loadForm();
-			$this->validateForm();
-			$this->parse();
-			$this->display();
-		}
-		
-		// the item does not exist
-		else $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
+            $this->getData();
+            $this->loadForm();
+            $this->validateForm();
+            $this->parse();
+            $this->display();
+        }
+        
+        // the item does not exist
+        else {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 
-	/**
-	 * Get the data
-	 */
-	protected function getData()
-	{
-		$this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
-		$this->file = BackendCatalogModel::getFile($this->getParameter('id', 'int'));
-		$this->file['data'] = unserialize($this->record['data']);
-		$this->file['link'] = $this->record['data']['link'];
+    /**
+     * Get the data
+     */
+    protected function getData()
+    {
+        $this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
+        $this->file = BackendCatalogModel::getFile($this->getParameter('id', 'int'));
+        $this->file['data'] = unserialize($this->record['data']);
+        $this->file['link'] = $this->record['data']['link'];
+    }
 
-	}
+    /**
+     * Load the form
+     */
+    protected function loadForm()
+    {
+        $this->frm = new BackendForm('editFile');
+        $this->frm->addText('title', $this->file['title']);
+        $this->frm->addFile('file');
+        $this->frm->getField('file')->setAttribute('extension', implode(', ', $this->allowedExtensions));
+    }
 
-	/**
-	 * Load the form
-	 */
-	protected function loadForm()
-	{
-		$this->frm = new BackendForm('editFile');
-		$this->frm->addText('title', $this->file['title']);
-		$this->frm->addFile('file');
-		$this->frm->getField('file')->setAttribute('extension', implode(', ', $this->allowedExtensions));
-	}
+    /**
+     * Parse the form
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-	/**
-	 * Parse the form
-	 */
-	protected function parse()
-	{
-		parent::parse();
+        $this->tpl->assign('id', $this->id);
+        $this->tpl->assign('item', $this->file);
+    }
 
-		$this->tpl->assign('id', $this->id);
-		$this->tpl->assign('item', $this->file);
-	}
+    /**
+     * Validate the form
+     */
+    protected function validateForm()
+    {
+        // is the form submitted?
+        if ($this->frm->isSubmitted()) {
+            // cleanup the submitted fields, ignore fields that were added by hackers
+            $this->frm->cleanupFields();
 
-	/**
-	 * Validate the form
-	 */
-	protected function validateForm()
-	{
-		// is the form submitted?
-		if($this->frm->isSubmitted()) {
-			// cleanup the submitted fields, ignore fields that were added by hackers
-			$this->frm->cleanupFields();
+            // validate fields
+            $file = $this->frm->getField('file');
 
-			// validate fields
-			$file = $this->frm->getField('file');
+            $this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
+            if ($this->file['filename'] === null) {
+                $file->isFilled(BL::err('FieldIsRequired'));
+            }
 
-			$this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
-			if($this->file['filename'] === null) $file->isFilled(BL::err('FieldIsRequired'));
+            // validate the file
+            if ($this->frm->getField('file')->isFilled()) {
+                // file extension
+                $this->frm->getField('file')->isAllowedExtension($this->allowedExtensions, BL::err('FileExtensionNotAllowed'));
+            }
 
-			// validate the file
-			if($this->frm->getField('file')->isFilled()) {
-			    // file extension
-			    $this->frm->getField('file')->isAllowedExtension($this->allowedExtensions, BL::err('FileExtensionNotAllowed'));
-			}
+            // no errors?
+            if ($this->frm->isCorrect()) {
+                // build image record to insert
+                $item['id'] = $this->id;
+                $item['title'] = $this->frm->getField('title')->getValue();
+                $item['filename'] = $this->file['filename'];
+                
+                // the file path
+                $filePath = FRONTEND_FILES_PATH . '/' . $this->getModule() . '/' . $this->project['id'] . '/source';
+                
+                if ($file->isFilled()) {
+                    $item['filename'] = time() . '.' . $file->getExtension();
+                    $file->moveFile($filePath . '/' . $item['filename']);
+                }
+                
+                // save the item
+                $id = BackendCatalogModel::saveFile($item);
 
-			// no errors?
-			if($this->frm->isCorrect()) {
-				// build image record to insert
-				$item['id'] = $this->id;
-				$item['title'] = $this->frm->getField('title')->getValue();
-				$item['filename'] = $this->file['filename'];
-				
-				// the file path
-				$filePath = FRONTEND_FILES_PATH . '/' . $this->getModule() . '/' . $this->project['id'] . '/source';
-				
-				if($file->isFilled()) {
-					$item['filename'] = time() . '.' . $file->getExtension();
-					$file->moveFile($filePath . '/' . $item['filename']);
-				}
-				
-				// save the item
-				$id = BackendCatalogModel::saveFile($item);
-
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_edit_file', array('item' => $item));
-								
-				// everything is saved, so redirect to the overview
-				$this->redirect(BackendModel::createURLForAction('media') . '&product_id=' . $this->product['id'] . '&report=edited&var=' . urlencode($item['title']) . '&highlight=row-' . $id . '#tabFiles');
-			}
-		}
-	}
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_edit_file', array('item' => $item));
+                                
+                // everything is saved, so redirect to the overview
+                $this->redirect(BackendModel::createURLForAction('media') . '&product_id=' . $this->product['id'] . '&report=edited&var=' . urlencode($item['title']) . '&highlight=row-' . $id . '#tabFiles');
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/EditImage.php
+++ b/src/Backend/Modules/Catalog/Actions/EditImage.php
@@ -24,123 +24,127 @@ use Backend\Modules\Catalog\Engine\Helper as BackendCatalogHelper;
  */
 class EditImage extends BackendBaseActionEdit
 {
-	/**
-	 * The product
-	 *
-	 * @var	array
-	 */
-	private $product;
+    /**
+     * The product
+     *
+     * @var	array
+     */
+    private $product;
     
-	/**
-	 * The image of a product
-	 *
-	 * @var	array
-	 */
-	private $image;
+    /**
+     * The image of a product
+     *
+     * @var	array
+     */
+    private $image;
 
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('id', 'int');
-		if($this->id !== null && BackendCatalogModel::existsImage($this->id)) {
-			parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('id', 'int');
+        if ($this->id !== null && BackendCatalogModel::existsImage($this->id)) {
+            parent::execute();
 
-			$this->getData();
-			$this->loadForm();
-			$this->validateForm();
-			$this->parse();
-			$this->display();
-		}
-		// the item does not exist
-		else $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
+            $this->getData();
+            $this->loadForm();
+            $this->validateForm();
+            $this->parse();
+            $this->display();
+        }
+        // the item does not exist
+        else {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 
-	/**
-	 * Get the data
-	 */
-	protected function getData()
-	{
-		$this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
-		$this->image = BackendCatalogModel::getImage($this->getParameter('id', 'int'));
-		$this->image['data'] = unserialize($this->record['data']);
-		$this->image['link'] = $this->record['data']['link'];
-	}
+    /**
+     * Get the data
+     */
+    protected function getData()
+    {
+        $this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
+        $this->image = BackendCatalogModel::getImage($this->getParameter('id', 'int'));
+        $this->image['data'] = unserialize($this->record['data']);
+        $this->image['link'] = $this->record['data']['link'];
+    }
 
-	/**
-	 * Load the form
-	 */
-	protected function loadForm()
-	{
-		$this->frm = new BackendForm('editImage');
-		$this->frm->addText('title', $this->image['title']);
-		$this->frm->addImage('image');
-	}
+    /**
+     * Load the form
+     */
+    protected function loadForm()
+    {
+        $this->frm = new BackendForm('editImage');
+        $this->frm->addText('title', $this->image['title']);
+        $this->frm->addImage('image');
+    }
 
-	/**
-	 * Parse the form
-	 */
-	protected function parse()
-	{
-		parent::parse();
-				
-		$this->tpl->assign('product', $this->product);
-		$this->tpl->assign('id', $this->id);
-		$this->tpl->assign('item', $this->image);
-	}
+    /**
+     * Parse the form
+     */
+    protected function parse()
+    {
+        parent::parse();
+                
+        $this->tpl->assign('product', $this->product);
+        $this->tpl->assign('id', $this->id);
+        $this->tpl->assign('item', $this->image);
+    }
 
-	/**
-	 * Validate the form
-	 */
-	protected function validateForm()
-	{
-		// is the form submitted?
-		if($this->frm->isSubmitted()) {
-			// cleanup the submitted fields, ignore fields that were added by hackers
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    protected function validateForm()
+    {
+        // is the form submitted?
+        if ($this->frm->isSubmitted()) {
+            // cleanup the submitted fields, ignore fields that were added by hackers
+            $this->frm->cleanupFields();
 
-			// validate fields
-			$image = $this->frm->getField('image');
+            // validate fields
+            $image = $this->frm->getField('image');
 
-			$this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
-			if($this->image['filename'] === null) $image->isFilled(BL::err('FieldIsRequired'));
+            $this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
+            if ($this->image['filename'] === null) {
+                $image->isFilled(BL::err('FieldIsRequired'));
+            }
 
-			// no errors?
-			if($this->frm->isCorrect()) {
-				// build image record to insert
-				$item['id'] = $this->id;
-				$item['title'] = $this->frm->getField('title')->getValue();
-				$item['filename'] = $this->image['filename'];
+            // no errors?
+            if ($this->frm->isCorrect()) {
+                // build image record to insert
+                $item['id'] = $this->id;
+                $item['title'] = $this->frm->getField('title')->getValue();
+                $item['filename'] = $this->image['filename'];
 
-				// set files path for this record
-				$path = FRONTEND_FILES_PATH . '/' . $this->module . '/' . $this->product['id'];
-				$formats = array();
-				$formats[] = array('size' => '64x64', 'force_aspect_ratio' => false);
-				$formats[] = array('size' => '128x128', 'force_aspect_ratio' => false);
+                // set files path for this record
+                $path = FRONTEND_FILES_PATH . '/' . $this->module . '/' . $this->product['id'];
+                $formats = array();
+                $formats[] = array('size' => '64x64', 'force_aspect_ratio' => false);
+                $formats[] = array('size' => '128x128', 'force_aspect_ratio' => false);
                 $formats[] = array('size' => BackendModel::getModuleSetting($this->URL->getModule(), 'width1') . 'x' . BackendModel::getModuleSetting($this->URL->getModule(), 'height1'), 'allow_enlargement' => BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment1'), 'force_aspect_ratio' => BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio1'));
                 $formats[] = array('size' => BackendModel::getModuleSetting($this->URL->getModule(), 'width2') . 'x' . BackendModel::getModuleSetting($this->URL->getModule(), 'height2'), 'allow_enlargement' => BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment2'), 'force_aspect_ratio' => BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio2'));
                 $formats[] = array('size' => BackendModel::getModuleSetting($this->URL->getModule(), 'width3') . 'x' . BackendModel::getModuleSetting($this->URL->getModule(), 'height3'), 'allow_enlargement' => BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment3'), 'force_aspect_ratio' => BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio3'));
 
-				if($image->isFilled()) {
-					// overwrite the filename
-					if($item['filename'] === null) {
-						$item['filename'] = time() . '.' . $image->getExtension();
-					}
+                if ($image->isFilled()) {
+                    // overwrite the filename
+                    if ($item['filename'] === null) {
+                        $item['filename'] = time() . '.' . $image->getExtension();
+                    }
 
-					// add images
-					BackendCatalogHelper::addImages($image, $path, $item['filename'], $formats);
-				}
-				
-				// save the item
-				$id = BackendCatalogModel::saveImage($item);
+                    // add images
+                    BackendCatalogHelper::addImages($image, $path, $item['filename'], $formats);
+                }
+                
+                // save the item
+                $id = BackendCatalogModel::saveImage($item);
 
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_edit_image', array('item' => $item));
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_edit_image', array('item' => $item));
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(BackendModel::createURLForAction('media') . '&product_id=' . $this->product['id'] . '&report=edited&var=' . urlencode($item['title']) . '&highlight=row-' . $id);
-			}
-		}
-	}
+                // everything is saved, so redirect to the overview
+                $this->redirect(BackendModel::createURLForAction('media') . '&product_id=' . $this->product['id'] . '&report=edited&var=' . urlencode($item['title']) . '&highlight=row-' . $id);
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/EditOrder.php
+++ b/src/Backend/Modules/Catalog/Actions/EditOrder.php
@@ -24,120 +24,124 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class EditOrder extends BackendBaseActionEdit
 {
-	/**
-	 * DataGrids
-	 *
-	 * @var	BackendDataGridDB
-	 */
-	protected $dgProducts;
+    /**
+     * DataGrids
+     *
+     * @var	BackendDataGridDB
+     */
+    protected $dgProducts;
   
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('id', 'int');
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('id', 'int');
 
-		// does the item exist
-		if($this->id !== null && BackendCatalogModel::existsOrder($this->id)) {
-			parent::execute();
-			$this->getData();
-			$this->loadForm();
-			$this->validateForm();
-			$this->parse();
-			$this->display();
-		}
+        // does the item exist
+        if ($this->id !== null && BackendCatalogModel::existsOrder($this->id)) {
+            parent::execute();
+            $this->getData();
+            $this->loadForm();
+            $this->validateForm();
+            $this->parse();
+            $this->display();
+        }
 
-		// no item found, throw an exception, because somebody is fucking with our URL
-		else $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
+        // no item found, throw an exception, because somebody is fucking with our URL
+        else {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 
-	/**
-	 * Get the data
-	 * If a revision-id was specified in the URL we load the revision and not the actual data.
-	 */
-	private function getData()
-	{
-		// get the record
-		$this->record = (array) BackendCatalogModel::getOrder($this->id);
+    /**
+     * Get the data
+     * If a revision-id was specified in the URL we load the revision and not the actual data.
+     */
+    private function getData()
+    {
+        // get the record
+        $this->record = (array) BackendCatalogModel::getOrder($this->id);
         
-		// dataGrid for the products within an order
-		$this->dgProducts = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_PRODUCTS_ORDER, array($this->id));
+        // dataGrid for the products within an order
+        $this->dgProducts = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_PRODUCTS_ORDER, array($this->id));
 
-		// hide columns
-		$this->dgProducts->setColumnsHidden('order_id', 'product_id', 'url', 'date');
-			
-		// set column URLs
-		$this->dgProducts->setColumnURL('title', BackendModel::createURLForAction('edit') . '&amp;id=[product_id]');
-        
-		// no item found, throw an exceptions, because somebody is fucking with our URL
-		if(empty($this->record)) $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
-
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		// create form
-		$this->frm = new BackendForm('editOrder');
-
-		// create elements
-		$this->frm->addText('email', $this->record['email']);
-		$this->frm->addText('fname', $this->record['fname']);
-		$this->frm->addText('lname', $this->record['lname']);
-		$this->frm->addText('address', $this->record['address']);
-		$this->frm->addText('hnumber', $this->record['hnumber']);
-		$this->frm->addText('postal', $this->record['postal']);
-		$this->frm->addText('hometown', $this->record['hometown']);
-
-		// assign URL
-		//$this->tpl->assign('itemURL', BackendModel::getURLForBlock($this->getModule(), 'detail') . '/' . $this->record['product_url'] . '#order-' . $this->record['product_id']);
-			
-		$this->tpl->assign('products', $this->record);
-		$this->tpl->assign('dgProducts', ($this->dgProducts->getNumResults() != 0) ? $this->dgProducts->getContent() : false);
-		$this->tpl->assign('orderPerson', $this->record['fname']);
-	}
-
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			// cleanup the submitted fields, ignore fields that were added by hackers
-			$this->frm->cleanupFields();
-
-			// validate fields
-			$this->frm->getField('email')->isEmail(FL::err('EmailIsRequired'));
-			$this->frm->getField('fname')->isFilled(BL::err('FirstNameIsRequired'));
-			$this->frm->getField('lname')->isFilled(BL::err('LastNameIsRequired'));
-			$this->frm->getField('address')->isFilled(BL::err('AddressIsRequired'));
-			$this->frm->getField('hnumber')->isFilled(BL::err('HouseNumberIsRequired'));
-			$this->frm->getField('postal')->isFilled(BL::err('PostalIsRequired'));
-			$this->frm->getField('hometown')->isFilled(BL::err('HometownIsRequired'));
+        // hide columns
+        $this->dgProducts->setColumnsHidden('order_id', 'product_id', 'url', 'date');
             
-			// no errors?
-			if($this->frm->isCorrect()) {
-				// build item
-				$order['id'] = $this->id;
-				$order['email'] = $this->frm->getField('email')->getValue();
-				$order['fname'] = $this->frm->getField('fname')->getValue();
-				$order['lname'] = $this->frm->getField('lname')->getValue();
-				$order['address'] = $this->frm->getField('address')->getValue();
-				$order['hnumber'] = $this->frm->getField('hnumber')->getValue();
-				$order['postal'] = $this->frm->getField('postal')->getValue();
-				$order['hometown'] = $this->frm->getField('hometown')->getValue();
-	
-				// insert the item
-				BackendCatalogModel::updateOrder($order);
+        // set column URLs
+        $this->dgProducts->setColumnURL('title', BackendModel::createURLForAction('edit') . '&amp;id=[product_id]');
+        
+        // no item found, throw an exceptions, because somebody is fucking with our URL
+        if (empty($this->record)) {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_edit_order', array('item' => $order));
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        // create form
+        $this->frm = new BackendForm('editOrder');
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(BackendModel::createURLForAction('orders') . '&report=edited-order&id=' . $order['id'] . '&highlight=row-' . $order['id'] . '#tab' . ucwords($this->record['status']));
-			}
-		}
-	}
+        // create elements
+        $this->frm->addText('email', $this->record['email']);
+        $this->frm->addText('fname', $this->record['fname']);
+        $this->frm->addText('lname', $this->record['lname']);
+        $this->frm->addText('address', $this->record['address']);
+        $this->frm->addText('hnumber', $this->record['hnumber']);
+        $this->frm->addText('postal', $this->record['postal']);
+        $this->frm->addText('hometown', $this->record['hometown']);
+
+        // assign URL
+        //$this->tpl->assign('itemURL', BackendModel::getURLForBlock($this->getModule(), 'detail') . '/' . $this->record['product_url'] . '#order-' . $this->record['product_id']);
+            
+        $this->tpl->assign('products', $this->record);
+        $this->tpl->assign('dgProducts', ($this->dgProducts->getNumResults() != 0) ? $this->dgProducts->getContent() : false);
+        $this->tpl->assign('orderPerson', $this->record['fname']);
+    }
+
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            // cleanup the submitted fields, ignore fields that were added by hackers
+            $this->frm->cleanupFields();
+
+            // validate fields
+            $this->frm->getField('email')->isEmail(FL::err('EmailIsRequired'));
+            $this->frm->getField('fname')->isFilled(BL::err('FirstNameIsRequired'));
+            $this->frm->getField('lname')->isFilled(BL::err('LastNameIsRequired'));
+            $this->frm->getField('address')->isFilled(BL::err('AddressIsRequired'));
+            $this->frm->getField('hnumber')->isFilled(BL::err('HouseNumberIsRequired'));
+            $this->frm->getField('postal')->isFilled(BL::err('PostalIsRequired'));
+            $this->frm->getField('hometown')->isFilled(BL::err('HometownIsRequired'));
+            
+            // no errors?
+            if ($this->frm->isCorrect()) {
+                // build item
+                $order['id'] = $this->id;
+                $order['email'] = $this->frm->getField('email')->getValue();
+                $order['fname'] = $this->frm->getField('fname')->getValue();
+                $order['lname'] = $this->frm->getField('lname')->getValue();
+                $order['address'] = $this->frm->getField('address')->getValue();
+                $order['hnumber'] = $this->frm->getField('hnumber')->getValue();
+                $order['postal'] = $this->frm->getField('postal')->getValue();
+                $order['hometown'] = $this->frm->getField('hometown')->getValue();
+    
+                // insert the item
+                BackendCatalogModel::updateOrder($order);
+
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_edit_order', array('item' => $order));
+
+                // everything is saved, so redirect to the overview
+                $this->redirect(BackendModel::createURLForAction('orders') . '&report=edited-order&id=' . $order['id'] . '&highlight=row-' . $order['id'] . '#tab' . ucwords($this->record['status']));
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/EditSpecification.php
+++ b/src/Backend/Modules/Catalog/Actions/EditSpecification.php
@@ -23,104 +23,104 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class EditSpecification extends BackendBaseActionEdit
 {
-	/**
-	 * The specification id
-	 *
-	 * @var	array
-	 */
-	protected $id;
+    /**
+     * The specification id
+     *
+     * @var	array
+     */
+    protected $id;
     
-	/**
-	 * The specification record
-	 *
-	 * @var	array
-	 */
-	protected $record;
+    /**
+     * The specification record
+     *
+     * @var	array
+     */
+    protected $record;
     
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
 
-		$this->getData();
-		$this->loadForm();
-		$this->validateForm();
+        $this->getData();
+        $this->loadForm();
+        $this->validateForm();
 
-		$this->parse();
-		$this->display();
-	}
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Get the data
-	 */
-	private function getData()
-	{
-		$this->id = $this->getParameter('id', 'int');
-		
-		if($this->id == null || !BackendCatalogModel::existsSpecification($this->id)) {
-			$this->redirect(
-				BackendModel::createURLForAction('specifications') . '&error=non-existing'
-			);
-		}
+    /**
+     * Get the data
+     */
+    private function getData()
+    {
+        $this->id = $this->getParameter('id', 'int');
+        
+        if ($this->id == null || !BackendCatalogModel::existsSpecification($this->id)) {
+            $this->redirect(
+                BackendModel::createURLForAction('specifications') . '&error=non-existing'
+            );
+        }
 
-		$this->record = BackendCatalogModel::getSpecification($this->id);
-	}
+        $this->record = BackendCatalogModel::getSpecification($this->id);
+    }
 
-	/**
-	 * Parse the form
-	 */
-	protected function parse()
-	{
-		parent::parse();
+    /**
+     * Parse the form
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-		// assign the data
-		$this->tpl->assign('item', $this->record);
-	}
+        // assign the data
+        $this->tpl->assign('item', $this->record);
+    }
 
-	/**
-	 * Load the form
-	 */
-	private function loadForm()
-	{
-		$this->frm = new BackendForm('editSpecification');
-		$this->frm->addText('title', $this->record['title']);
-		$this->meta = new BackendMeta($this->frm, $this->record['meta_id'], 'title', true);
-		$this->meta->setUrlCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForSpecification', array($this->record['id']));
-	}
+    /**
+     * Load the form
+     */
+    private function loadForm()
+    {
+        $this->frm = new BackendForm('editSpecification');
+        $this->frm->addText('title', $this->record['title']);
+        $this->meta = new BackendMeta($this->frm, $this->record['meta_id'], 'title', true);
+        $this->meta->setUrlCallback('Backend\Modules\Catalog\Engine\Model', 'getURLForSpecification', array($this->record['id']));
+    }
 
-	/**
-	 * Validate the form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            $this->frm->cleanupFields();
 
-			// validate fields
-			$this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
-						
-			$this->meta->validate();
+            // validate fields
+            $this->frm->getField('title')->isFilled(BL::err('TitleIsRequired'));
+                        
+            $this->meta->validate();
 
-			if($this->frm->isCorrect()) {
-				// build item
-				$item['id'] = $this->id;
-				$item['title'] = $this->frm->getField('title')->getValue();
-				$item['language'] = BL::getWorkingLanguage();
-				$item['meta_id'] = $this->meta->save(true);
+            if ($this->frm->isCorrect()) {
+                // build item
+                $item['id'] = $this->id;
+                $item['title'] = $this->frm->getField('title')->getValue();
+                $item['language'] = BL::getWorkingLanguage();
+                $item['meta_id'] = $this->meta->save(true);
                 
-				// save the data
-				BackendCatalogModel::updateSpecification($item['id'], $item);
-				
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_edit_specification', array('item' => $item));
+                // save the data
+                BackendCatalogModel::updateSpecification($item['id'], $item);
+                
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_edit_specification', array('item' => $item));
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(
-					BackendModel::createURLForAction('specifications') . '&report=edited-specification&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']
-				);
-			}
-		}
-	}    
+                // everything is saved, so redirect to the overview
+                $this->redirect(
+                    BackendModel::createURLForAction('specifications') . '&report=edited-specification&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id']
+                );
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/EditVideo.php
+++ b/src/Backend/Modules/Catalog/Actions/EditVideo.php
@@ -22,101 +22,103 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class EditVideo extends BackendBaseActionEdit
 {
-	/**
-	 * The product
-	 *
-	 * @var	array
-	 */
-	private $product;
+    /**
+     * The product
+     *
+     * @var	array
+     */
+    private $product;
     
-	/**
-	 * The video of a product
-	 *
-	 * @var	array
-	 */
-	private $video;
+    /**
+     * The video of a product
+     *
+     * @var	array
+     */
+    private $video;
     
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('id', 'int');
-		if($this->id !== null && BackendCatalogModel::existsVideo($this->id)) {
-			parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('id', 'int');
+        if ($this->id !== null && BackendCatalogModel::existsVideo($this->id)) {
+            parent::execute();
 
-			$this->getData();
-			$this->loadForm();
-			$this->validateForm();
-			$this->parse();
-			$this->display();
-		}
-		// the item does not exist
-		else $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
+            $this->getData();
+            $this->loadForm();
+            $this->validateForm();
+            $this->parse();
+            $this->display();
+        }
+        // the item does not exist
+        else {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
+    }
 
-	/**
-	 * Get the data
-	 */
-	protected function getData()
-	{
-		$this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
-		$this->video = BackendCatalogModel::getVideo($this->getParameter('id', 'int'));
-		$this->video['data'] = unserialize($this->record['data']);
-		$this->video['link'] = $this->record['data']['link'];
-	}
+    /**
+     * Get the data
+     */
+    protected function getData()
+    {
+        $this->product = BackendCatalogModel::get($this->getParameter('product_id', 'int'));
+        $this->video = BackendCatalogModel::getVideo($this->getParameter('id', 'int'));
+        $this->video['data'] = unserialize($this->record['data']);
+        $this->video['link'] = $this->record['data']['link'];
+    }
 
-	/**
-	 * Load the form
-	 */
-	protected function loadForm()
-	{
-		$this->frm = new BackendForm('editVideo');
-		$this->frm->addText('title', $this->video['title']);
-		$this->frm->addTextArea('video', $this->video['embedded_url']);
-	}
+    /**
+     * Load the form
+     */
+    protected function loadForm()
+    {
+        $this->frm = new BackendForm('editVideo');
+        $this->frm->addText('title', $this->video['title']);
+        $this->frm->addTextArea('video', $this->video['embedded_url']);
+    }
 
-	/**
-	 * Parse the form
-	 */
-	protected function parse()
-	{
-		parent::parse();
+    /**
+     * Parse the form
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-		$this->tpl->assign('id', $this->id);
-		$this->tpl->assign('item', $this->video);
-	}
+        $this->tpl->assign('id', $this->id);
+        $this->tpl->assign('item', $this->video);
+    }
 
-	/**
-	 * Validate the form
-	 */
-	protected function validateForm()
-	{
-		// is the form submitted?
-		if($this->frm->isSubmitted()) {
-			// cleanup the submitted fields, ignore fields that were added by hackers
-			$this->frm->cleanupFields();
+    /**
+     * Validate the form
+     */
+    protected function validateForm()
+    {
+        // is the form submitted?
+        if ($this->frm->isSubmitted()) {
+            // cleanup the submitted fields, ignore fields that were added by hackers
+            $this->frm->cleanupFields();
 
-			// validate fields
-			$this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
-			$this->frm->getField('video')->isFilled(BL::err('FieldIsRequired'));
+            // validate fields
+            $this->frm->getField('title')->isFilled(BL::err('NameIsRequired'));
+            $this->frm->getField('video')->isFilled(BL::err('FieldIsRequired'));
 
-			// no errors?
-			if($this->frm->isCorrect()) {
-				// build image record to insert
-				$item['id'] = $this->id;
-				$item['title'] = $this->frm->getField('title')->getValue();
-				$item['embedded_url'] = $this->frm->getField('video')->getValue();
-				
-				// save the item
-				$id = BackendCatalogModel::saveVideo($item);
+            // no errors?
+            if ($this->frm->isCorrect()) {
+                // build image record to insert
+                $item['id'] = $this->id;
+                $item['title'] = $this->frm->getField('title')->getValue();
+                $item['embedded_url'] = $this->frm->getField('video')->getValue();
+                
+                // save the item
+                $id = BackendCatalogModel::saveVideo($item);
 
-				// trigger event
-				BackendModel::triggerEvent($this->getModule(), 'after_edit_video', array('item' => $item));
+                // trigger event
+                BackendModel::triggerEvent($this->getModule(), 'after_edit_video', array('item' => $item));
 
-				// everything is saved, so redirect to the overview
-				$this->redirect(BackendModel::createURLForAction('media') . '&product_id=' . $this->product['id'] . '&report=edited&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id'] . '#tabVideos');
-			}
-		}
-	}
+                // everything is saved, so redirect to the overview
+                $this->redirect(BackendModel::createURLForAction('media') . '&product_id=' . $this->product['id'] . '&report=edited&var=' . urlencode($item['title']) . '&highlight=row-' . $item['id'] . '#tabVideos');
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/Index.php
+++ b/src/Backend/Modules/Catalog/Actions/Index.php
@@ -25,130 +25,133 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class Index extends BackendBaseActionIndex
 {
-	/**
-	 * The category where is filtered on
-	 *
-	 * @var	array
-	 */
-	private $category;
+    /**
+     * The category where is filtered on
+     *
+     * @var	array
+     */
+    private $category;
 
-	/**
-	 * The id of the category where is filtered on
-	 *
-	 * @var	int
-	 */
-	private $categoryId;
+    /**
+     * The id of the category where is filtered on
+     *
+     * @var	int
+     */
+    private $categoryId;
 
-	/**
-	 * DataGrids
-	 *
-	 * @var	SpoonDataGrid
-	 */
-	private $dgProducts;
-	
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
-		
-		$this->categoryId = \SpoonFilter::getGetValue('category', null, null, 'int');
-		if($this->categoryId == 0) $this->categoryId = null;
-		else {
-			// get category
-			$this->category = BackendCatalogModel::getCategory($this->categoryId);
-						
-			// reset
-			if(empty($this->category)) {
-				// reset GET to trick Spoon
-				$_GET['category'] = null;
+    /**
+     * DataGrids
+     *
+     * @var	SpoonDataGrid
+     */
+    private $dgProducts;
+    
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
+        
+        $this->categoryId = \SpoonFilter::getGetValue('category', null, null, 'int');
+        if ($this->categoryId == 0) {
+            $this->categoryId = null;
+        } else {
+            // get category
+            $this->category = BackendCatalogModel::getCategory($this->categoryId);
+                        
+            // reset
+            if (empty($this->category)) {
+                // reset GET to trick Spoon
+                $_GET['category'] = null;
 
-				// reset
-				$this->categoryId = null;
-			}
-		}
-		
-		$this->loadDataGrid();
+                // reset
+                $this->categoryId = null;
+            }
+        }
+        
+        $this->loadDataGrid();
 
-		$this->parse();
-		$this->display();
-	}
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Load the dataGrid
-	 */
-	private function loadDataGrid()
-	{
-		// filter category
-		if($this->categoryId != null ) {			
-			// create datagrid
-			$this->dgProducts = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_FOR_CATEGORY, array($this->categoryId, BL::getWorkingLanguage()));
-			
-			// set the URL
-			$this->dgProducts->setURL('&amp;category=' . $this->categoryId, true);
-		} else {
-			// dont filter category
-			// create datagrid
-			$this->dgProducts = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE, array(BL::getWorkingLanguage()));
-		}
+    /**
+     * Load the dataGrid
+     */
+    private function loadDataGrid()
+    {
+        // filter category
+        if ($this->categoryId != null) {
+            // create datagrid
+            $this->dgProducts = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_FOR_CATEGORY, array($this->categoryId, BL::getWorkingLanguage()));
+            
+            // set the URL
+            $this->dgProducts->setURL('&amp;category=' . $this->categoryId, true);
+        } else {
+            // dont filter category
+            // create datagrid
+            $this->dgProducts = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE, array(BL::getWorkingLanguage()));
+        }
 
-		// our JS needs to know an id, so we can highlight it
-		$this->dgProducts->setRowAttributes(array('id' => 'row-[id]'));
-		$this->dgProducts->setColumnsHidden(array('category_id', 'sequence'));
-		
-		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('Edit')) {			
-			// set column URLs
-			$this->dgProducts->setColumnURL('title', BackendModel::createURLForAction('edit') . '&amp;id=[id]&amp;category=' . $this->categoryId);
+        // our JS needs to know an id, so we can highlight it
+        $this->dgProducts->setRowAttributes(array('id' => 'row-[id]'));
+        $this->dgProducts->setColumnsHidden(array('category_id', 'sequence'));
+        
+        // check if this action is allowed
+        if (BackendAuthentication::isAllowedAction('Edit')) {
+            // set column URLs
+            $this->dgProducts->setColumnURL('title', BackendModel::createURLForAction('edit') . '&amp;id=[id]&amp;category=' . $this->categoryId);
 
-			// add edit and media column
-			$this->dgProducts->addColumn('media', null, BL::lbl('Media'), BackendModel::createURLForAction('media') . '&amp;id=[id]', BL::lbl('Media'));
-			$this->dgProducts->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit') . '&amp;id=[id]&amp;category=' . $this->categoryId, BL::lbl('Edit'));
-		
-			// set media column function
-			$this->dgProducts->setColumnFunction(array(__CLASS__, 'setMediaLink'), array('[id]'), 'media');
-		}
-	}
+            // add edit and media column
+            $this->dgProducts->addColumn('media', null, BL::lbl('Media'), BackendModel::createURLForAction('media') . '&amp;id=[id]', BL::lbl('Media'));
+            $this->dgProducts->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit') . '&amp;id=[id]&amp;category=' . $this->categoryId, BL::lbl('Edit'));
+        
+            // set media column function
+            $this->dgProducts->setColumnFunction(array(__CLASS__, 'setMediaLink'), array('[id]'), 'media');
+        }
+    }
 
-	/**
-	 * Parse the page
-	 */
-	protected function parse()
-	{		
-		// parse the datagrid for all products
-		$this->tpl->assign('dgProducts', ($this->dgProducts->getNumResults() != 0) ? $this->dgProducts->getContent() : false);
-	
-		// get categories
-		$categories = BackendCatalogModel::getCategories(true);
-				
-		// multiple categories?
-		if(count($categories) > 1) {
-			// create form
-			$frm = new BackendForm('filter', null, 'get', true);
+    /**
+     * Parse the page
+     */
+    protected function parse()
+    {
+        // parse the datagrid for all products
+        $this->tpl->assign('dgProducts', ($this->dgProducts->getNumResults() != 0) ? $this->dgProducts->getContent() : false);
+    
+        // get categories
+        $categories = BackendCatalogModel::getCategories(true);
+                
+        // multiple categories?
+        if (count($categories) > 1) {
+            // create form
+            $frm = new BackendForm('filter', null, 'get', true);
 
-			// create element
-			$frm->addDropdown('category', $categories, $this->categoryId);
-			$frm->getField('category')->setDefaultElement('');
-			
-			// parse the form
-			$frm->parse($this->tpl);
-		}
+            // create element
+            $frm->addDropdown('category', $categories, $this->categoryId);
+            $frm->getField('category')->setDefaultElement('');
+            
+            // parse the form
+            $frm->parse($this->tpl);
+        }
 
-		// parse category
-		if(!empty($this->category)) $this->tpl->assign('filterCategory', $this->category);	
-	}
-	
-	/**
-	 * Sets a link to the media overview
-	 *
-	 * @param int $productId The specific id of the product
-	 * @return string
-	 */
-	public static function setMediaLink($productId)
-	{
-		return '<a class="button icon iconEdit linkButton" href="' . BackendModel::createURLForAction('media') . '&product_id=' . $productId . '">
+        // parse category
+        if (!empty($this->category)) {
+            $this->tpl->assign('filterCategory', $this->category);
+        }
+    }
+    
+    /**
+     * Sets a link to the media overview
+     *
+     * @param int $productId The specific id of the product
+     * @return string
+     */
+    public static function setMediaLink($productId)
+    {
+        return '<a class="button icon iconEdit linkButton" href="' . BackendModel::createURLForAction('media') . '&product_id=' . $productId . '">
 					<span>' . BL::lbl('ManageMedia') . '</span>
 				</a>';
-	}
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/MassCommentAction.php
+++ b/src/Backend/Modules/Catalog/Actions/MassCommentAction.php
@@ -20,112 +20,132 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class MassCommentAction extends BackendBaseAction
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
 
-		// current status
-		$from = \SpoonFilter::getGetValue('from', array('published', 'moderation', 'spam'), 'published');
+        // current status
+        $from = \SpoonFilter::getGetValue('from', array('published', 'moderation', 'spam'), 'published');
 
-		// action to execute
-		$action = \SpoonFilter::getGetValue('action', array('published', 'moderation', 'spam', 'delete'), 'spam');
+        // action to execute
+        $action = \SpoonFilter::getGetValue('action', array('published', 'moderation', 'spam', 'delete'), 'spam');
 
-		// no id's provided
-		if(!isset($_GET['id'])) $this->redirect(BackendModel::createURLForAction('comments') . '&error=no-comments-selected');
+        // no id's provided
+        if (!isset($_GET['id'])) {
+            $this->redirect(BackendModel::createURLForAction('comments') . '&error=no-comments-selected');
+        }
 
-		// redefine id's
-		$ids = (array) $_GET['id'];
+        // redefine id's
+        $ids = (array) $_GET['id'];
 
-		// delete comment(s)
-		if($action == 'delete') BackendCatalogModel::deleteComments($ids);
+        // delete comment(s)
+        if ($action == 'delete') {
+            BackendCatalogModel::deleteComments($ids);
+        }
 
-		// spam
-		elseif($action == 'spam') {
-			// is the spamfilter active?
-			if(BackendModel::getModuleSetting($this->URL->getModule(), 'spamfilter', false)) {
-				// get data
-				$comments = BackendCatalogModel::getComments($ids);
+        // spam
+        elseif ($action == 'spam') {
+            // is the spamfilter active?
+            if (BackendModel::getModuleSetting($this->URL->getModule(), 'spamfilter', false)) {
+                // get data
+                $comments = BackendCatalogModel::getComments($ids);
 
-				// loop comments
-				foreach($comments as $row) {
-					// unserialize data
-					$row['data'] = unserialize($row['data']);
+                // loop comments
+                foreach ($comments as $row) {
+                    // unserialize data
+                    $row['data'] = unserialize($row['data']);
 
-					// check if needed data is available
-					if(!isset($row['data']['server']['REMOTE_ADDR'])) continue;
-					if(!isset($row['data']['server']['HTTP_USER_AGENT'])) continue;
+                    // check if needed data is available
+                    if (!isset($row['data']['server']['REMOTE_ADDR'])) {
+                        continue;
+                    }
+                    if (!isset($row['data']['server']['HTTP_USER_AGENT'])) {
+                        continue;
+                    }
 
-					// build vars
-					$userIp = $row['data']['server']['REMOTE_ADDR'];
-					$userAgent = $row['data']['server']['HTTP_USER_AGENT'];
-					$content = $row['text'];
-					$author = $row['author'];
-					$email = $row['email'];
-					$url = (isset($row['website']) && $row['website'] != '') ? $row['website'] : null;
-					$referrer = (isset($row['data']['server']['HTTP_REFERER'])) ? $row['data']['server']['HTTP_REFERER'] : null;
-					$others = $row['data']['server'];
+                    // build vars
+                    $userIp = $row['data']['server']['REMOTE_ADDR'];
+                    $userAgent = $row['data']['server']['HTTP_USER_AGENT'];
+                    $content = $row['text'];
+                    $author = $row['author'];
+                    $email = $row['email'];
+                    $url = (isset($row['website']) && $row['website'] != '') ? $row['website'] : null;
+                    $referrer = (isset($row['data']['server']['HTTP_REFERER'])) ? $row['data']['server']['HTTP_REFERER'] : null;
+                    $others = $row['data']['server'];
 
-					// submit as spam
-					BackendModel::submitSpam($userIp, $userAgent, $content, $author, $email, $url, null, 'comment', $referrer, $others);
-				}
-			}
+                    // submit as spam
+                    BackendModel::submitSpam($userIp, $userAgent, $content, $author, $email, $url, null, 'comment', $referrer, $others);
+                }
+            }
 
-			// set new status
-			BackendCatalogModel::updateCommentStatuses($ids, $action);
-		} else {
-			// other actions data
-			// published?
-			if($action == 'published') {
-				// is the spamfilter active?
-				if(BackendModel::getModuleSetting($this->URL->getModule(), 'spamfilter', false)) {
-					// get data
-					$comments = BackendCatalogModel::getComments($ids);
+            // set new status
+            BackendCatalogModel::updateCommentStatuses($ids, $action);
+        } else {
+            // other actions data
+            // published?
+            if ($action == 'published') {
+                // is the spamfilter active?
+                if (BackendModel::getModuleSetting($this->URL->getModule(), 'spamfilter', false)) {
+                    // get data
+                    $comments = BackendCatalogModel::getComments($ids);
 
-					// loop comments
-					foreach($comments as $row) {
-						// previous status is spam
-						if($row['status'] == 'spam') {
-							// unserialize data
-							$row['data'] = unserialize($row['data']);
+                    // loop comments
+                    foreach ($comments as $row) {
+                        // previous status is spam
+                        if ($row['status'] == 'spam') {
+                            // unserialize data
+                            $row['data'] = unserialize($row['data']);
 
-							// check if needed data is available
-							if(!isset($row['data']['server']['REMOTE_ADDR'])) continue;
-							if(!isset($row['data']['server']['HTTP_USER_AGENT'])) continue;
+                            // check if needed data is available
+                            if (!isset($row['data']['server']['REMOTE_ADDR'])) {
+                                continue;
+                            }
+                            if (!isset($row['data']['server']['HTTP_USER_AGENT'])) {
+                                continue;
+                            }
 
-							// build vars
-							$userIp = $row['data']['server']['REMOTE_ADDR'];
-							$userAgent = $row['data']['server']['HTTP_USER_AGENT'];
-							$content = $row['text'];
-							$author = $row['author'];
-							$email = $row['email'];
-							$url = (isset($row['website']) && $row['website'] != '') ? $row['website'] : null;
-							$referrer = (isset($row['data']['server']['HTTP_REFERER'])) ? $row['data']['server']['HTTP_REFERER'] : null;
-							$others = $row['data']['server'];
+                            // build vars
+                            $userIp = $row['data']['server']['REMOTE_ADDR'];
+                            $userAgent = $row['data']['server']['HTTP_USER_AGENT'];
+                            $content = $row['text'];
+                            $author = $row['author'];
+                            $email = $row['email'];
+                            $url = (isset($row['website']) && $row['website'] != '') ? $row['website'] : null;
+                            $referrer = (isset($row['data']['server']['HTTP_REFERER'])) ? $row['data']['server']['HTTP_REFERER'] : null;
+                            $others = $row['data']['server'];
 
-							// submit as spam
-							BackendModel::submitHam($userIp, $userAgent, $content, $author, $email, $url, null, 'comment', $referrer, $others);
-						}
-					}
-				}
-			}
+                            // submit as spam
+                            BackendModel::submitHam($userIp, $userAgent, $content, $author, $email, $url, null, 'comment', $referrer, $others);
+                        }
+                    }
+                }
+            }
 
-			// set new status
-			BackendCatalogModel::updateCommentStatuses($ids, $action);
-		}
+            // set new status
+            BackendCatalogModel::updateCommentStatuses($ids, $action);
+        }
 
-		// define report
-		$report = (count($ids) > 1) ? 'comments-' : 'comment-';
+        // define report
+        $report = (count($ids) > 1) ? 'comments-' : 'comment-';
 
-		// init var
-		if($action == 'published') $report .= 'moved-published';
-		if($action == 'moderation') $report .= 'moved-moderation';
-		if($action == 'spam') $report .= 'moved-spam';
-		if($action == 'delete') $report .= 'deleted';
+        // init var
+        if ($action == 'published') {
+            $report .= 'moved-published';
+        }
+        if ($action == 'moderation') {
+            $report .= 'moved-moderation';
+        }
+        if ($action == 'spam') {
+            $report .= 'moved-spam';
+        }
+        if ($action == 'delete') {
+            $report .= 'deleted';
+        }
 
-		// redirect
-		$this->redirect(BackendModel::createURLForAction('comments') . '&report=' . $report . '#tab' . ucfirst($from));
-	}
+        // redirect
+        $this->redirect(BackendModel::createURLForAction('comments') . '&report=' . $report . '#tab' . ucfirst($from));
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/MassMediaAction.php
+++ b/src/Backend/Modules/Catalog/Actions/MassMediaAction.php
@@ -15,38 +15,39 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
 
 /**
  * This action is used to perform mass actions on product media (delete, ...)
- * 
+ *
  * @author Tim van Wolfswinkel <tim@webleads.nl>
  */
 class MassMediaAction extends BackendBaseAction
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
-		
-		// action to execute
-		$action = \SpoonFilter::getGetValue('action', array('deleteImages', 'deleteFiles', 'deleteVideos'), 'delete');
-		
-		if(!isset($_GET['id'])) $this->redirect(BackendModel::createURLForAction('index') . '&error=no-selection');
-		else {
-			// at least one id
-			// redefine id's
-			$aIds = (array) $_GET['id'];
-			$slideshowID = (int) $_GET['product_id'];
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
+        
+        // action to execute
+        $action = \SpoonFilter::getGetValue('action', array('deleteImages', 'deleteFiles', 'deleteVideos'), 'delete');
+        
+        if (!isset($_GET['id'])) {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=no-selection');
+        } else {
+            // at least one id
+            // redefine id's
+            $aIds = (array) $_GET['id'];
+            $slideshowID = (int) $_GET['product_id'];
 
-			// delete media
-			if($action == 'deleteImages') {
-				BackendCatalogModel::deleteImage($aIds);
-			} else if($action == 'deleteFiles') {
-				BackendCatalogModel::deleteFile($aIds);
-			} else if($action == 'deleteVideos') {
-				BackendCatalogModel::deleteVideo($aIds);
-			}
-		}
+            // delete media
+            if ($action == 'deleteImages') {
+                BackendCatalogModel::deleteImage($aIds);
+            } elseif ($action == 'deleteFiles') {
+                BackendCatalogModel::deleteFile($aIds);
+            } elseif ($action == 'deleteVideos') {
+                BackendCatalogModel::deleteVideo($aIds);
+            }
+        }
 
-		$this->redirect(BackendModel::createURLForAction('media') . '&product_id=' . $slideshowID . '&report=deleted');
-	}
+        $this->redirect(BackendModel::createURLForAction('media') . '&product_id=' . $slideshowID . '&report=deleted');
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/MassOrderAction.php
+++ b/src/Backend/Modules/Catalog/Actions/MassOrderAction.php
@@ -20,39 +20,53 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class MassOrderAction extends BackendBaseAction
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
 
-		// current status
-		$from = \SpoonFilter::getGetValue('from', array('moderation', 'completed'), 'moderation');
+        // current status
+        $from = \SpoonFilter::getGetValue('from', array('moderation', 'completed'), 'moderation');
 
-		// action to execute
-		$action = \SpoonFilter::getGetValue('action', array('moderation', 'completed', 'delete'), 'completed');
+        // action to execute
+        $action = \SpoonFilter::getGetValue('action', array('moderation', 'completed', 'delete'), 'completed');
 
-		// no id's provided
-		if(!isset($_GET['id'])) $this->redirect(BackendModel::createURLForAction('orders') . '&error=no-orders-selected');
+        // no id's provided
+        if (!isset($_GET['id'])) {
+            $this->redirect(BackendModel::createURLForAction('orders') . '&error=no-orders-selected');
+        }
 
-		// redefine id's
-		$ids = (array) $_GET['id'];
+        // redefine id's
+        $ids = (array) $_GET['id'];
 
-		// delete comment(s)
-		if($action == 'delete') BackendCatalogModel::deleteOrders($ids);
-		if($action == 'completed')BackendCatalogModel::updateOrderStatuses($ids, $action);
-		if($action == 'moderation')BackendCatalogModel::updateOrderStatuses($ids, $action);
+        // delete comment(s)
+        if ($action == 'delete') {
+            BackendCatalogModel::deleteOrders($ids);
+        }
+        if ($action == 'completed') {
+            BackendCatalogModel::updateOrderStatuses($ids, $action);
+        }
+        if ($action == 'moderation') {
+            BackendCatalogModel::updateOrderStatuses($ids, $action);
+        }
 
-		// define report
-		$report = (count($ids) > 1) ? 'orders-' : 'order-';
+        // define report
+        $report = (count($ids) > 1) ? 'orders-' : 'order-';
 
-		// init var
-		if($action == 'moderation') $report .= 'moved-moderation';
-		if($action == 'completed') $report .= 'moved-completed';
-		if($action == 'delete') $report .= 'deleted';
+        // init var
+        if ($action == 'moderation') {
+            $report .= 'moved-moderation';
+        }
+        if ($action == 'completed') {
+            $report .= 'moved-completed';
+        }
+        if ($action == 'delete') {
+            $report .= 'deleted';
+        }
 
-		// redirect
-		$this->redirect(BackendModel::createURLForAction('orders') . '&report=' . $report . '#tab' . ucfirst($from));
-	}
+        // redirect
+        $this->redirect(BackendModel::createURLForAction('orders') . '&report=' . $report . '#tab' . ucfirst($from));
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/Media.php
+++ b/src/Backend/Modules/Catalog/Actions/Media.php
@@ -25,166 +25,168 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class Media extends BackendBaseActionIndex
 {
-	/**
-	 * The product id
-	 *
-	 * @var	int
-	 */
-	private $id;
+    /**
+     * The product id
+     *
+     * @var	int
+     */
+    private $id;
 
-	/**
-	* The project record
-	*
-	* @var	array
-	*/
-	private $product;
+    /**
+    * The project record
+    *
+    * @var	array
+    */
+    private $product;
     
-	/**
-	 * Datagrid with published items
-	 *
-	 * @var	DataGrid
-	 */
-	protected $dgImages, $dgFiles, $dgVideos;
+    /**
+     * Datagrid with published items
+     *
+     * @var	DataGrid
+     */
+    protected $dgImages, $dgFiles, $dgVideos;
 
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		$this->id = $this->getParameter('product_id', 'int');
-		
-		if($this->id !== null && BackendCatalogModel::exists($this->id)) {
-			parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        $this->id = $this->getParameter('product_id', 'int');
+        
+        if ($this->id !== null && BackendCatalogModel::exists($this->id)) {
+            parent::execute();
 
-			$this->getData();
-			$this->loadDataGridImages();
-			$this->loadDataGridFiles();
-			$this->loadDataGridVideos();
-			$this->parse();
-			$this->display();
-		}
-		
-		// the project does not exist
-		else $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
-	}
-
-	/**
-	 * Gets all necessary data
-	 */
-	protected function getData()
-	{
-		$this->product = BackendCatalogModel::get($this->id);
-	}
-
-	/**
-	 * Loads the datagrid of the images
-	 */
-	protected function loadDataGridImages()
-	{
-		// set image link
-		$imageLink = FRONTEND_FILES_URL . '/' . $this->module . '/[product_id]/64x64';
-	    
-		// create images datagrid
-		$this->dgImages = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_IMAGES, $this->id);
-		$this->dgImages->setAttributes(array('class' => 'dataGrid sequenceByDragAndDrop'));
-		$this->dgImages->setAttributes(array('id' => 'products_images_dg'));	
-		  
-		$this->dgImages->setColumnHidden('sequence');
-		$this->dgImages->setColumnHidden('product_id');
-		  
-		$this->dgImages->addColumn('dragAndDropHandle', null, '<span>' . BL::lbl('Move') . '</span>');
-		$this->dgImages->setColumnsSequence('dragAndDropHandle');
-		$this->dgImages->setColumnAttributes('dragAndDropHandle', array('class' => 'dragAndDropHandle'));
-			  
-		$this->dgImages->setRowAttributes(array('data-id' => '[id]'));
-		$this->dgImages->setSortParameter('asc');
-		$this->dgImages->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_image') . '&amp;id=[id]&amp;product_id=[product_id]', BL::lbl('Edit'));
-	      
-		$this->dgImages->setColumnFunction(array(new BackendDataGridFunctions(), 'showImage'), array($imageLink, '[filename]'), 'filename');
-		$this->dgImages->setColumnAttributes('filename', array('class' => 'thumbnail'));
-		$this->dgImages->addColumn('checkbox', '<span class="checkboxHolder block"><input type="checkbox" name="toggleChecks" value="toggleChecks" />', '<input type="checkbox" name="id[]" value="[id]" class="inputCheckbox" /></span>');
-		$this->dgImages->setColumnsSequence('checkbox');
-	      
-		$ddmMassAction = new \SpoonFormDropdown('action', array('deleteImages' => BL::lbl('Delete')), 'deleteImages');
-		$this->dgImages->setMassAction($ddmMassAction);
-		$this->dgImages->setColumnAttributes('title', array('data-id' => '{id:[id]}'));
-	
-		$this->dgImages->setAttributes(array('data-action' => "SequenceMediaImages"));
+            $this->getData();
+            $this->loadDataGridImages();
+            $this->loadDataGridFiles();
+            $this->loadDataGridVideos();
+            $this->parse();
+            $this->display();
+        }
+        
+        // the project does not exist
+        else {
+            $this->redirect(BackendModel::createURLForAction('index') . '&error=non-existing');
+        }
     }
 
-	/**
-	 * Loads the datagrid of the files
-	 */
-	protected function loadDataGridFiles()
-	{
-		// create files datagrid
-		$this->dgFiles = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_FILES, $this->id);
-		
-		$this->dgFiles->setAttributes(array('class' => 'dataGrid sequenceByDragAndDrop'));
-		$this->dgFiles->setAttributes(array('id' => 'products_files_dg'));	
-	      
-		$this->dgFiles->setColumnHidden('sequence');
-		$this->dgFiles->setColumnHidden('product_id');
-	      
-		$this->dgFiles->addColumn('dragAndDropHandle', null, '<span>' . BL::lbl('Move') . '</span>');
-		$this->dgFiles->setColumnsSequence('dragAndDropHandle');
-		$this->dgFiles->setColumnAttributes('dragAndDropHandle', array('class' => 'dragAndDropHandle'));
-	      
-		$this->dgFiles->setRowAttributes(array('data-id' => '[id]'));	
-	      
-		$this->dgFiles->setSortingColumns(array('title', 'sequence'), 'sequence');
-		$this->dgFiles->setSortParameter('asc');
-	
-		$this->dgFiles->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_file') . '&amp;id=[id]&amp;product_id=[product_id]', BL::lbl('Edit'));      
-		$this->dgFiles->addColumn('checkbox', '<span class="checkboxHolder block"><input type="checkbox" name="toggleChecks" value="toggleChecks" />', '<input type="checkbox" name="id[]" value="[id]" class="inputCheckbox" /></span>');
-		$this->dgFiles->setColumnsSequence('checkbox');
-	      
-		$ddmMassAction = new \SpoonFormDropdown('action', array('deleteFiles' => BL::lbl('Delete')), 'deleteFiles');
-		$this->dgFiles->setMassAction($ddmMassAction);
-		$this->dgFiles->setColumnAttributes('title', array('data-id' => '{id:[id]}'));
-	}
+    /**
+     * Gets all necessary data
+     */
+    protected function getData()
+    {
+        $this->product = BackendCatalogModel::get($this->id);
+    }
 
-	/**
-	 * Loads the datagrid of the videos
-	 */
-	protected function loadDataGridVideos()
-	{
-		// create videos datagrid
-		$this->dgVideos = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_VIDEOS, $this->id);
-		  
-		$this->dgVideos->setAttributes(array('class' => 'dataGrid sequenceByDragAndDrop'));
-		$this->dgVideos->setAttributes(array('id' => 'products_videos_dg'));	
-		
-		$this->dgVideos->setColumnHidden('sequence');
-		$this->dgVideos->setColumnHidden('product_id');
-		      
-		$this->dgVideos->addColumn('dragAndDropHandle', null, '<span>' . BL::lbl('Move') . '</span>');
-		$this->dgVideos->setColumnsSequence('dragAndDropHandle');
-		$this->dgVideos->setColumnAttributes('dragAndDropHandle', array('class' => 'dragAndDropHandle'));
-		
-		$this->dgVideos->setRowAttributes(array('data-id' => '[id]'));	
-		
-		$this->dgVideos->setSortingColumns(array('title', 'sequence'), 'sequence');
-		$this->dgVideos->setSortParameter('asc');
-	  
-		$this->dgVideos->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_video') . '&amp;id=[id]&amp;product_id=[product_id]', BL::lbl('Edit'));
-		$this->dgVideos->addColumn('checkbox', '<span class="checkboxHolder block"><input type="checkbox" name="toggleChecks" value="toggleChecks" />', '<input type="checkbox" name="id[]" value="[id]" class="inputCheckbox" /></span>');
-		$this->dgVideos->setColumnsSequence('checkbox');
-		
-		$ddmMassAction = new \SpoonFormDropdown('action', array('deleteVideos' => BL::lbl('Delete')), 'deleteVideos');
-		$this->dgVideos->setMassAction($ddmMassAction);
-		$this->dgVideos->setColumnAttributes('title', array('data-id' => '{id:[id]}'));
-	}
-    
-	/**
-	 * Parse & display the page
-	 */
-	protected function parse()
-	{
-		$this->tpl->assign('dataGridImages', ($this->dgImages->getNumResults() != 0) ? $this->dgImages->getContent() : false);
-		$this->tpl->assign('dataGridFiles', ($this->dgFiles->getNumResults() != 0) ? $this->dgFiles->getContent() : false);
-		$this->tpl->assign('dataGridVideos', ($this->dgVideos->getNumResults() != 0) ? $this->dgVideos->getContent() : false);
+    /**
+     * Loads the datagrid of the images
+     */
+    protected function loadDataGridImages()
+    {
+        // set image link
+        $imageLink = FRONTEND_FILES_URL . '/' . $this->module . '/[product_id]/64x64';
         
-		$this->tpl->assign('product', $this->product);
-	}
+        // create images datagrid
+        $this->dgImages = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_IMAGES, $this->id);
+        $this->dgImages->setAttributes(array('class' => 'dataGrid sequenceByDragAndDrop'));
+        $this->dgImages->setAttributes(array('id' => 'products_images_dg'));
+          
+        $this->dgImages->setColumnHidden('sequence');
+        $this->dgImages->setColumnHidden('product_id');
+          
+        $this->dgImages->addColumn('dragAndDropHandle', null, '<span>' . BL::lbl('Move') . '</span>');
+        $this->dgImages->setColumnsSequence('dragAndDropHandle');
+        $this->dgImages->setColumnAttributes('dragAndDropHandle', array('class' => 'dragAndDropHandle'));
+              
+        $this->dgImages->setRowAttributes(array('data-id' => '[id]'));
+        $this->dgImages->setSortParameter('asc');
+        $this->dgImages->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_image') . '&amp;id=[id]&amp;product_id=[product_id]', BL::lbl('Edit'));
+          
+        $this->dgImages->setColumnFunction(array(new BackendDataGridFunctions(), 'showImage'), array($imageLink, '[filename]'), 'filename');
+        $this->dgImages->setColumnAttributes('filename', array('class' => 'thumbnail'));
+        $this->dgImages->addColumn('checkbox', '<span class="checkboxHolder block"><input type="checkbox" name="toggleChecks" value="toggleChecks" />', '<input type="checkbox" name="id[]" value="[id]" class="inputCheckbox" /></span>');
+        $this->dgImages->setColumnsSequence('checkbox');
+          
+        $ddmMassAction = new \SpoonFormDropdown('action', array('deleteImages' => BL::lbl('Delete')), 'deleteImages');
+        $this->dgImages->setMassAction($ddmMassAction);
+        $this->dgImages->setColumnAttributes('title', array('data-id' => '{id:[id]}'));
+    
+        $this->dgImages->setAttributes(array('data-action' => "SequenceMediaImages"));
+    }
+
+    /**
+     * Loads the datagrid of the files
+     */
+    protected function loadDataGridFiles()
+    {
+        // create files datagrid
+        $this->dgFiles = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_FILES, $this->id);
+        
+        $this->dgFiles->setAttributes(array('class' => 'dataGrid sequenceByDragAndDrop'));
+        $this->dgFiles->setAttributes(array('id' => 'products_files_dg'));
+          
+        $this->dgFiles->setColumnHidden('sequence');
+        $this->dgFiles->setColumnHidden('product_id');
+          
+        $this->dgFiles->addColumn('dragAndDropHandle', null, '<span>' . BL::lbl('Move') . '</span>');
+        $this->dgFiles->setColumnsSequence('dragAndDropHandle');
+        $this->dgFiles->setColumnAttributes('dragAndDropHandle', array('class' => 'dragAndDropHandle'));
+          
+        $this->dgFiles->setRowAttributes(array('data-id' => '[id]'));
+          
+        $this->dgFiles->setSortingColumns(array('title', 'sequence'), 'sequence');
+        $this->dgFiles->setSortParameter('asc');
+    
+        $this->dgFiles->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_file') . '&amp;id=[id]&amp;product_id=[product_id]', BL::lbl('Edit'));
+        $this->dgFiles->addColumn('checkbox', '<span class="checkboxHolder block"><input type="checkbox" name="toggleChecks" value="toggleChecks" />', '<input type="checkbox" name="id[]" value="[id]" class="inputCheckbox" /></span>');
+        $this->dgFiles->setColumnsSequence('checkbox');
+          
+        $ddmMassAction = new \SpoonFormDropdown('action', array('deleteFiles' => BL::lbl('Delete')), 'deleteFiles');
+        $this->dgFiles->setMassAction($ddmMassAction);
+        $this->dgFiles->setColumnAttributes('title', array('data-id' => '{id:[id]}'));
+    }
+
+    /**
+     * Loads the datagrid of the videos
+     */
+    protected function loadDataGridVideos()
+    {
+        // create videos datagrid
+        $this->dgVideos = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_VIDEOS, $this->id);
+          
+        $this->dgVideos->setAttributes(array('class' => 'dataGrid sequenceByDragAndDrop'));
+        $this->dgVideos->setAttributes(array('id' => 'products_videos_dg'));
+        
+        $this->dgVideos->setColumnHidden('sequence');
+        $this->dgVideos->setColumnHidden('product_id');
+              
+        $this->dgVideos->addColumn('dragAndDropHandle', null, '<span>' . BL::lbl('Move') . '</span>');
+        $this->dgVideos->setColumnsSequence('dragAndDropHandle');
+        $this->dgVideos->setColumnAttributes('dragAndDropHandle', array('class' => 'dragAndDropHandle'));
+        
+        $this->dgVideos->setRowAttributes(array('data-id' => '[id]'));
+        
+        $this->dgVideos->setSortingColumns(array('title', 'sequence'), 'sequence');
+        $this->dgVideos->setSortParameter('asc');
+      
+        $this->dgVideos->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_video') . '&amp;id=[id]&amp;product_id=[product_id]', BL::lbl('Edit'));
+        $this->dgVideos->addColumn('checkbox', '<span class="checkboxHolder block"><input type="checkbox" name="toggleChecks" value="toggleChecks" />', '<input type="checkbox" name="id[]" value="[id]" class="inputCheckbox" /></span>');
+        $this->dgVideos->setColumnsSequence('checkbox');
+        
+        $ddmMassAction = new \SpoonFormDropdown('action', array('deleteVideos' => BL::lbl('Delete')), 'deleteVideos');
+        $this->dgVideos->setMassAction($ddmMassAction);
+        $this->dgVideos->setColumnAttributes('title', array('data-id' => '{id:[id]}'));
+    }
+    
+    /**
+     * Parse & display the page
+     */
+    protected function parse()
+    {
+        $this->tpl->assign('dataGridImages', ($this->dgImages->getNumResults() != 0) ? $this->dgImages->getContent() : false);
+        $this->tpl->assign('dataGridFiles', ($this->dgFiles->getNumResults() != 0) ? $this->dgFiles->getContent() : false);
+        $this->tpl->assign('dataGridVideos', ($this->dgVideos->getNumResults() != 0) ? $this->dgVideos->getContent() : false);
+        
+        $this->tpl->assign('product', $this->product);
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/Orders.php
+++ b/src/Backend/Modules/Catalog/Actions/Orders.php
@@ -24,139 +24,139 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class Orders extends BackendBaseActionIndex
 {
-	/**
-	 * DataGrids
-	 *
-	 * @var	BackendDataGridDB
-	 */
-	protected $dgModeration, $dgCompleted;
+    /**
+     * DataGrids
+     *
+     * @var	BackendDataGridDB
+     */
+    protected $dgModeration, $dgCompleted;
 
-	/**
-	 * Add productdata into the order
-	 *
-	 * @param  string $text The order.
-	 * @param string $title The title for the product.
-	 * @param string $URL The URL for the product.
-	 * @param int $id The id of the order.
-	 * @return string
-	 */
-	public static function addProductData($text, $title, $URL, $id)
-	{
-		// reset URL
-		$URL = BackendModel::getURLForBlock('catalog', 'detail') . '/' . $URL . '#order-' . $id;
+    /**
+     * Add productdata into the order
+     *
+     * @param  string $text The order.
+     * @param string $title The title for the product.
+     * @param string $URL The URL for the product.
+     * @param int $id The id of the order.
+     * @return string
+     */
+    public static function addProductData($text, $title, $URL, $id)
+    {
+        // reset URL
+        $URL = BackendModel::getURLForBlock('catalog', 'detail') . '/' . $URL . '#order-' . $id;
 
-		// build HTML
-		return '<p><em>' . sprintf(BL::msg('OrderOnWithURL'), $URL, $title) . '</em></p>' . "\n" . (string) $text;
-	}
+        // build HTML
+        return '<p><em>' . sprintf(BL::msg('OrderOnWithURL'), $URL, $title) . '</em></p>' . "\n" . (string) $text;
+    }
 
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
-		$this->loadDataGrids();
-		$this->parse();
-		$this->display();
-	}
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
+        $this->loadDataGrids();
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Loads the datagrids
-	 */
-	private function loadDataGrids()
-	{
-		/*
-		 * DataGrid for the orders that are awaiting moderation.
-		 */
-		$this->dgModeration = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_ORDERS, array('moderation'));
+    /**
+     * Loads the datagrids
+     */
+    private function loadDataGrids()
+    {
+        /*
+         * DataGrid for the orders that are awaiting moderation.
+         */
+        $this->dgModeration = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_ORDERS, array('moderation'));
 
-		// active tab
-		$this->dgModeration->setActiveTab('tabModeration');
+        // active tab
+        $this->dgModeration->setActiveTab('tabModeration');
 
-		// num items per page
-		$this->dgModeration->setPagingLimit(30);
+        // num items per page
+        $this->dgModeration->setPagingLimit(30);
 
-		// header labels
-		$this->dgModeration->setHeaderLabels(array('ordered_on' => ucfirst(BL::lbl('Date'))));
+        // header labels
+        $this->dgModeration->setHeaderLabels(array('ordered_on' => ucfirst(BL::lbl('Date'))));
 
-		// add the multicheckbox column
-		$this->dgModeration->setMassActionCheckboxes('checkbox', '[id]');
+        // add the multicheckbox column
+        $this->dgModeration->setMassActionCheckboxes('checkbox', '[id]');
 
-		// assign column functions
-		$this->dgModeration->setColumnFunction(array(new BackendDataGridFunctions(), 'getTimeAgo'), '[ordered_on]', 'ordered_on', true);
+        // assign column functions
+        $this->dgModeration->setColumnFunction(array(new BackendDataGridFunctions(), 'getTimeAgo'), '[ordered_on]', 'ordered_on', true);
 
-		// sorting
-		$this->dgModeration->setSortingColumns(array('ordered_on', 'order_nr'), 'ordered_on');
-		$this->dgModeration->setSortParameter('desc');
+        // sorting
+        $this->dgModeration->setSortingColumns(array('ordered_on', 'order_nr'), 'ordered_on');
+        $this->dgModeration->setSortParameter('desc');
 
-		// hide columns
-		$this->dgModeration->setColumnsHidden('status');
+        // hide columns
+        $this->dgModeration->setColumnsHidden('status');
 
-		// add mass action dropdown
-		$ddmMassAction = new \SpoonFormDropdown('action', array('completed' => BL::lbl('MoveToCompleted'), 'delete' => BL::lbl('Delete')), 'completed');
-		$ddmMassAction->setAttribute('id', 'actionModeration');
-		$ddmMassAction->setOptionAttributes('delete', array('data-message-id' => 'confirmDeleteModeration'));
-		$ddmMassAction->setOptionAttributes('completed', array('data-message-id' => 'confirmCompletedModeration'));
-		$this->dgModeration->setMassAction($ddmMassAction);
-		
-		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('EditOrder')) {
-			$this->dgModeration->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_order') . '&amp;id=[id]', BL::lbl('Edit'));
-		}
+        // add mass action dropdown
+        $ddmMassAction = new \SpoonFormDropdown('action', array('completed' => BL::lbl('MoveToCompleted'), 'delete' => BL::lbl('Delete')), 'completed');
+        $ddmMassAction->setAttribute('id', 'actionModeration');
+        $ddmMassAction->setOptionAttributes('delete', array('data-message-id' => 'confirmDeleteModeration'));
+        $ddmMassAction->setOptionAttributes('completed', array('data-message-id' => 'confirmCompletedModeration'));
+        $this->dgModeration->setMassAction($ddmMassAction);
+        
+        // check if this action is allowed
+        if (BackendAuthentication::isAllowedAction('EditOrder')) {
+            $this->dgModeration->addColumn('edit', null, BL::lbl('Edit'), BackendModel::createURLForAction('edit_order') . '&amp;id=[id]', BL::lbl('Edit'));
+        }
 
-		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('MassOrderAction')) {
-			$this->dgModeration->addColumn('approve', null, BL::lbl('Approve'), BackendModel::createURLForAction('mass_order_action') . '&amp;id=[id]&amp;from=moderation&amp;action=completed', BL::lbl('Approve'));
-		}
+        // check if this action is allowed
+        if (BackendAuthentication::isAllowedAction('MassOrderAction')) {
+            $this->dgModeration->addColumn('approve', null, BL::lbl('Approve'), BackendModel::createURLForAction('mass_order_action') . '&amp;id=[id]&amp;from=moderation&amp;action=completed', BL::lbl('Approve'));
+        }
 
-		/*
-		 * DataGrid for the orders that are marked as completed
-		 */
-		$this->dgCompleted = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_ORDERS, array('completed'));
+        /*
+         * DataGrid for the orders that are marked as completed
+         */
+        $this->dgCompleted = new BackendDataGridDB(BackendCatalogModel::QRY_DATAGRID_BROWSE_ORDERS, array('completed'));
 
-		// active tab
-		$this->dgCompleted->setActiveTab('tabCompleted');
+        // active tab
+        $this->dgCompleted->setActiveTab('tabCompleted');
 
-		// num items per page
-		$this->dgCompleted->setPagingLimit(30);
+        // num items per page
+        $this->dgCompleted->setPagingLimit(30);
 
-		// header labels
-		$this->dgCompleted->setHeaderLabels(array('ordered_on' => ucfirst(BL::lbl('Date'))));
+        // header labels
+        $this->dgCompleted->setHeaderLabels(array('ordered_on' => ucfirst(BL::lbl('Date'))));
 
-		// add the multicheckbox column
-		$this->dgCompleted->setMassActionCheckboxes('checkbox', '[id]');
+        // add the multicheckbox column
+        $this->dgCompleted->setMassActionCheckboxes('checkbox', '[id]');
 
-		// assign column functions
-		$this->dgCompleted->setColumnFunction(array(new BackendDataGridFunctions(), 'getTimeAgo'), '[ordered_on]', 'ordered_on', true);
+        // assign column functions
+        $this->dgCompleted->setColumnFunction(array(new BackendDataGridFunctions(), 'getTimeAgo'), '[ordered_on]', 'ordered_on', true);
 
-		// sorting
-		$this->dgCompleted->setSortingColumns(array('ordered_on'), 'ordered_on');
-		$this->dgCompleted->setSortParameter('desc');
+        // sorting
+        $this->dgCompleted->setSortingColumns(array('ordered_on'), 'ordered_on');
+        $this->dgCompleted->setSortParameter('desc');
 
-		// hide columns
-		$this->dgCompleted->setColumnsHidden('status');
+        // hide columns
+        $this->dgCompleted->setColumnsHidden('status');
 
-		// add mass action dropdown
-		$ddmMassAction = new \SpoonFormDropdown('action', array('moderation' => BL::lbl('MoveToModeration'), 'delete' => BL::lbl('Delete')), 'moderation');
-		$ddmMassAction->setAttribute('id', 'actionCompleted');
-		$ddmMassAction->setOptionAttributes('delete', array('data-message-id' => 'confirmDeleteCompleted'));
-		
-		$this->dgCompleted->setMassAction($ddmMassAction);
-	}
+        // add mass action dropdown
+        $ddmMassAction = new \SpoonFormDropdown('action', array('moderation' => BL::lbl('MoveToModeration'), 'delete' => BL::lbl('Delete')), 'moderation');
+        $ddmMassAction->setAttribute('id', 'actionCompleted');
+        $ddmMassAction->setOptionAttributes('delete', array('data-message-id' => 'confirmDeleteCompleted'));
+        
+        $this->dgCompleted->setMassAction($ddmMassAction);
+    }
 
-	/**
-	 * Parse & display the page
-	 */
-	protected function parse()
-	{
-		parent::parse();
+    /**
+     * Parse & display the page
+     */
+    protected function parse()
+    {
+        parent::parse();
 
-		// moderation datagrid and num results
-		$this->tpl->assign('dgModeration', ($this->dgModeration->getNumResults() != 0) ? $this->dgModeration->getContent() : false);
-		$this->tpl->assign('numModeration', $this->dgModeration->getNumResults());
+        // moderation datagrid and num results
+        $this->tpl->assign('dgModeration', ($this->dgModeration->getNumResults() != 0) ? $this->dgModeration->getContent() : false);
+        $this->tpl->assign('numModeration', $this->dgModeration->getNumResults());
 
-		// spam datagrid and num results
-		$this->tpl->assign('dgCompleted', ($this->dgCompleted->getNumResults() != 0) ? $this->dgCompleted->getContent() : false);
-		$this->tpl->assign('numCompleted', $this->dgCompleted->getNumResults());
-	}
+        // spam datagrid and num results
+        $this->tpl->assign('dgCompleted', ($this->dgCompleted->getNumResults() != 0) ? $this->dgCompleted->getContent() : false);
+        $this->tpl->assign('numCompleted', $this->dgCompleted->getNumResults());
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/Settings.php
+++ b/src/Backend/Modules/Catalog/Actions/Settings.php
@@ -21,105 +21,105 @@ use Backend\Core\Engine\Form as BackendForm;
  */
 class Settings extends BackendBaseActionEdit
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
 
-		$this->loadForm();
-		$this->validateForm();
+        $this->loadForm();
+        $this->validateForm();
 
-		$this->parse();
-		$this->display();
-	}
+        $this->parse();
+        $this->display();
+    }
 
-	/**
-	 * Loads the settings form
-	 */
-	private function loadForm()
-	{
-		// init settings form
-		$this->frm = new BackendForm('settings');
-		
-		// add fields for pagination
-		$this->frm->addDropdown('overview_number_of_items', array_combine(range(1, 30), range(1, 30)), BackendModel::getModuleSetting($this->URL->getModule(), 'overview_num_items', 10));
-		$this->frm->addDropdown('recent_products_full_number_of_items', array_combine(range(1, 10), range(1, 10)), BackendModel::getModuleSetting($this->URL->getModule(), 'recent_products_full_num_items', 5));
-		//$this->frm->addDropdown('recent_products_list_number_of_items', array_combine(range(1, 10), range(1, 10)), BackendModel::getModuleSetting($this->URL->getModule(), 'recent_articles_list_num_items', 5));
-		
-		// add fields for spam
-		$this->frm->addCheckbox('spamfilter', BackendModel::getModuleSetting($this->URL->getModule(), 'spamfilter', false));
-		
-		// no Akismet-key, so we can't enable spam-filter
-		if(BackendModel::getModuleSetting('core', 'akismet_key') == '') {
-			$this->frm->getField('spamfilter')->setAttribute('disabled', 'disabled');
-			$this->tpl->assign('noAkismetKey', true);
-		}
-		
-		// add fields for comments
-		$this->frm->addCheckbox('allow_comments', BackendModel::getModuleSetting($this->URL->getModule(), 'allow_comments', false));
-		$this->frm->addCheckbox('moderation', BackendModel::getModuleSetting($this->URL->getModule(), 'moderation', false));
+    /**
+     * Loads the settings form
+     */
+    private function loadForm()
+    {
+        // init settings form
+        $this->frm = new BackendForm('settings');
+        
+        // add fields for pagination
+        $this->frm->addDropdown('overview_number_of_items', array_combine(range(1, 30), range(1, 30)), BackendModel::getModuleSetting($this->URL->getModule(), 'overview_num_items', 10));
+        $this->frm->addDropdown('recent_products_full_number_of_items', array_combine(range(1, 10), range(1, 10)), BackendModel::getModuleSetting($this->URL->getModule(), 'recent_products_full_num_items', 5));
+        //$this->frm->addDropdown('recent_products_list_number_of_items', array_combine(range(1, 10), range(1, 10)), BackendModel::getModuleSetting($this->URL->getModule(), 'recent_articles_list_num_items', 5));
+        
+        // add fields for spam
+        $this->frm->addCheckbox('spamfilter', BackendModel::getModuleSetting($this->URL->getModule(), 'spamfilter', false));
+        
+        // no Akismet-key, so we can't enable spam-filter
+        if (BackendModel::getModuleSetting('core', 'akismet_key') == '') {
+            $this->frm->getField('spamfilter')->setAttribute('disabled', 'disabled');
+            $this->tpl->assign('noAkismetKey', true);
+        }
+        
+        // add fields for comments
+        $this->frm->addCheckbox('allow_comments', BackendModel::getModuleSetting($this->URL->getModule(), 'allow_comments', false));
+        $this->frm->addCheckbox('moderation', BackendModel::getModuleSetting($this->URL->getModule(), 'moderation', false));
 
-		// add fields for notifications
-		$this->frm->addCheckbox('notify_by_email_on_new_comment_to_moderate', BackendModel::getModuleSetting($this->URL->getModule(), 'notify_by_email_on_new_comment_to_moderate', false));
-		$this->frm->addCheckbox('notify_by_email_on_new_comment', BackendModel::getModuleSetting($this->URL->getModule(), 'notify_by_email_on_new_comment', false));
+        // add fields for notifications
+        $this->frm->addCheckbox('notify_by_email_on_new_comment_to_moderate', BackendModel::getModuleSetting($this->URL->getModule(), 'notify_by_email_on_new_comment_to_moderate', false));
+        $this->frm->addCheckbox('notify_by_email_on_new_comment', BackendModel::getModuleSetting($this->URL->getModule(), 'notify_by_email_on_new_comment', false));
 
-		// add fields for images
-		$this->frm->addText('width1', BackendModel::getModuleSetting($this->URL->getModule(), 'width1', false));
-		$this->frm->addText('height1', BackendModel::getModuleSetting($this->URL->getModule(), 'height1', false));
-		$this->frm->addCheckbox('allow_enlargment1', BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment1', false));
-		$this->frm->addCheckbox('force_aspect_ratio1', BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio1', false));
-		
-		$this->frm->addText('width2', BackendModel::getModuleSetting($this->URL->getModule(), 'width2', false));
-		$this->frm->addText('height2', BackendModel::getModuleSetting($this->URL->getModule(), 'height2', false));
-		$this->frm->addCheckbox('allow_enlargment2', BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment2', false));
-		$this->frm->addCheckbox('force_aspect_ratio2', BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio2', false));
-		
-		$this->frm->addText('width3', BackendModel::getModuleSetting($this->URL->getModule(), 'width3', false));
-		$this->frm->addText('height3', BackendModel::getModuleSetting($this->URL->getModule(), 'height3', false));
-		$this->frm->addCheckbox('allow_enlargment3', BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment3', false));
-		$this->frm->addCheckbox('force_aspect_ratio3', BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio3', false));
-				
-		$this->frm->addCheckbox('allow_multiple_categories', BackendModel::getModuleSetting($this->URL->getModule(), 'allow_multiple_categories', false));
-	}
+        // add fields for images
+        $this->frm->addText('width1', BackendModel::getModuleSetting($this->URL->getModule(), 'width1', false));
+        $this->frm->addText('height1', BackendModel::getModuleSetting($this->URL->getModule(), 'height1', false));
+        $this->frm->addCheckbox('allow_enlargment1', BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment1', false));
+        $this->frm->addCheckbox('force_aspect_ratio1', BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio1', false));
+        
+        $this->frm->addText('width2', BackendModel::getModuleSetting($this->URL->getModule(), 'width2', false));
+        $this->frm->addText('height2', BackendModel::getModuleSetting($this->URL->getModule(), 'height2', false));
+        $this->frm->addCheckbox('allow_enlargment2', BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment2', false));
+        $this->frm->addCheckbox('force_aspect_ratio2', BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio2', false));
+        
+        $this->frm->addText('width3', BackendModel::getModuleSetting($this->URL->getModule(), 'width3', false));
+        $this->frm->addText('height3', BackendModel::getModuleSetting($this->URL->getModule(), 'height3', false));
+        $this->frm->addCheckbox('allow_enlargment3', BackendModel::getModuleSetting($this->URL->getModule(), 'allow_enlargment3', false));
+        $this->frm->addCheckbox('force_aspect_ratio3', BackendModel::getModuleSetting($this->URL->getModule(), 'force_aspect_ratio3', false));
+                
+        $this->frm->addCheckbox('allow_multiple_categories', BackendModel::getModuleSetting($this->URL->getModule(), 'allow_multiple_categories', false));
+    }
 
-	/**
-	 * Validates the settings form
-	 */
-	private function validateForm()
-	{
-		if($this->frm->isSubmitted()) {
-			if($this->frm->isCorrect()) {
-				// set our settings
-				BackendModel::setModuleSetting($this->URL->getModule(), 'overview_num_items', (int) $this->frm->getField('overview_number_of_items')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'recent_products_full_num_items', (int) $this->frm->getField('recent_products_full_number_of_items')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'spamfilter', (bool) $this->frm->getField('spamfilter')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'allow_comments', (bool) $this->frm->getField('allow_comments')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'moderation', (bool) $this->frm->getField('moderation')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'notify_by_email_on_new_comment_to_moderate', (bool) $this->frm->getField('notify_by_email_on_new_comment_to_moderate')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'notify_by_email_on_new_comment', (bool) $this->frm->getField('notify_by_email_on_new_comment')->getValue());				
-				
-				BackendModel::setModuleSetting($this->URL->getModule(), 'width1', (int) $this->frm->getField('width1')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'height1', (int) $this->frm->getField('height1')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'allow_enlargment1', (bool) $this->frm->getField('allow_enlargment1')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'force_aspect_ratio1', (bool) $this->frm->getField('force_aspect_ratio1')->getValue());
-				
-				BackendModel::setModuleSetting($this->URL->getModule(), 'width2', (int) $this->frm->getField('width2')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'height2', (int) $this->frm->getField('height2')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'allow_enlargment2', (bool) $this->frm->getField('allow_enlargment2')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'force_aspect_ratio2', (bool) $this->frm->getField('force_aspect_ratio2')->getValue());
-				
-				BackendModel::setModuleSetting($this->URL->getModule(), 'width3', (int) $this->frm->getField('width3')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'height3', (int) $this->frm->getField('height3')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'allow_enlargment3', (bool) $this->frm->getField('allow_enlargment3')->getValue());
-				BackendModel::setModuleSetting($this->URL->getModule(), 'force_aspect_ratio3', (bool) $this->frm->getField('force_aspect_ratio3')->getValue());
-								
-				BackendModel::setModuleSetting($this->URL->getModule(), 'allow_multiple_categories', (bool) $this->frm->getField('allow_multiple_categories')->getValue());
+    /**
+     * Validates the settings form
+     */
+    private function validateForm()
+    {
+        if ($this->frm->isSubmitted()) {
+            if ($this->frm->isCorrect()) {
+                // set our settings
+                BackendModel::setModuleSetting($this->URL->getModule(), 'overview_num_items', (int) $this->frm->getField('overview_number_of_items')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'recent_products_full_num_items', (int) $this->frm->getField('recent_products_full_number_of_items')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'spamfilter', (bool) $this->frm->getField('spamfilter')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'allow_comments', (bool) $this->frm->getField('allow_comments')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'moderation', (bool) $this->frm->getField('moderation')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'notify_by_email_on_new_comment_to_moderate', (bool) $this->frm->getField('notify_by_email_on_new_comment_to_moderate')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'notify_by_email_on_new_comment', (bool) $this->frm->getField('notify_by_email_on_new_comment')->getValue());
+                
+                BackendModel::setModuleSetting($this->URL->getModule(), 'width1', (int) $this->frm->getField('width1')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'height1', (int) $this->frm->getField('height1')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'allow_enlargment1', (bool) $this->frm->getField('allow_enlargment1')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'force_aspect_ratio1', (bool) $this->frm->getField('force_aspect_ratio1')->getValue());
+                
+                BackendModel::setModuleSetting($this->URL->getModule(), 'width2', (int) $this->frm->getField('width2')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'height2', (int) $this->frm->getField('height2')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'allow_enlargment2', (bool) $this->frm->getField('allow_enlargment2')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'force_aspect_ratio2', (bool) $this->frm->getField('force_aspect_ratio2')->getValue());
+                
+                BackendModel::setModuleSetting($this->URL->getModule(), 'width3', (int) $this->frm->getField('width3')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'height3', (int) $this->frm->getField('height3')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'allow_enlargment3', (bool) $this->frm->getField('allow_enlargment3')->getValue());
+                BackendModel::setModuleSetting($this->URL->getModule(), 'force_aspect_ratio3', (bool) $this->frm->getField('force_aspect_ratio3')->getValue());
+                                
+                BackendModel::setModuleSetting($this->URL->getModule(), 'allow_multiple_categories', (bool) $this->frm->getField('allow_multiple_categories')->getValue());
 
-				// redirect to the settings page
-				$this->redirect(BackendModel::createURLForAction('settings') . '&report=saved');
-			}
-		}
-	}
+                // redirect to the settings page
+                $this->redirect(BackendModel::createURLForAction('settings') . '&report=saved');
+            }
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Actions/Specifications.php
+++ b/src/Backend/Modules/Catalog/Actions/Specifications.php
@@ -32,48 +32,48 @@ class Specifications extends BackendBaseActionIndex
     protected $dataGrid;
 
     /**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		parent::execute();		
-		$this->loadDataGrid();
+     * Execute the action
+     */
+    public function execute()
+    {
+        parent::execute();
+        $this->loadDataGrid();
 
-		$this->parse();
-		$this->display();
-	}
-	
-	/**
-	 * Load the dataGrid
-	 */
-	private function loadDataGrid()
-	{
-		$this->dataGrid = new BackendDataGridDB(
-			BackendCatalogModel::QRY_DATAGRID_BROWSE_SPECIFICATIONS,
-			BL::getWorkingLanguage()
-		);
-	
-		// check if this action is allowed
-		if(BackendAuthentication::isAllowedAction('EditSpecification')) {
-			$this->dataGrid->setColumnURL('specification', BackendModel::createURLForAction('edit_specification') . '&amp;id=[id]');
-			
-			$this->dataGrid->addColumn(
-				'edit', null, BL::lbl('Edit'),
-				BackendModel::createURLForAction('edit_specification') . '&amp;id=[id]',
-				BL::lbl('Edit')
-			);
-		}
+        $this->parse();
+        $this->display();
+    }
+    
+    /**
+     * Load the dataGrid
+     */
+    private function loadDataGrid()
+    {
+        $this->dataGrid = new BackendDataGridDB(
+            BackendCatalogModel::QRY_DATAGRID_BROWSE_SPECIFICATIONS,
+            BL::getWorkingLanguage()
+        );
+    
+        // check if this action is allowed
+        if (BackendAuthentication::isAllowedAction('EditSpecification')) {
+            $this->dataGrid->setColumnURL('specification', BackendModel::createURLForAction('edit_specification') . '&amp;id=[id]');
+            
+            $this->dataGrid->addColumn(
+                'edit', null, BL::lbl('Edit'),
+                BackendModel::createURLForAction('edit_specification') . '&amp;id=[id]',
+                BL::lbl('Edit')
+            );
+        }
 
-		// sequence
-		$this->dataGrid->enableSequenceByDragAndDrop();
-		$this->dataGrid->setAttributes(array('data-action' => 'SequenceSpecifications'));
-	}
-	
-	/**
-	 * Parse & display the page
-	 */
-	protected function parse()
-	{
-		$this->tpl->assign('dataGrid', (string) $this->dataGrid->getContent());
-	}
+        // sequence
+        $this->dataGrid->enableSequenceByDragAndDrop();
+        $this->dataGrid->setAttributes(array('data-action' => 'SequenceSpecifications'));
+    }
+    
+    /**
+     * Parse & display the page
+     */
+    protected function parse()
+    {
+        $this->tpl->assign('dataGrid', (string) $this->dataGrid->getContent());
+    }
 }

--- a/src/Backend/Modules/Catalog/Ajax/SequenceBrands.php
+++ b/src/Backend/Modules/Catalog/Ajax/SequenceBrands.php
@@ -19,26 +19,28 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class SequenceBrands extends BackendBaseAJAXAction
 {
-	public function execute()
-	{
-		parent::execute();
+    public function execute()
+    {
+        parent::execute();
 
-		// get parameters
-		$newIdSequence = trim(\SpoonFilter::getPostValue('new_id_sequence', null, '', 'string'));
+        // get parameters
+        $newIdSequence = trim(\SpoonFilter::getPostValue('new_id_sequence', null, '', 'string'));
 
-		// list id
-		$ids = (array) explode(',', rtrim($newIdSequence, ','));
+        // list id
+        $ids = (array) explode(',', rtrim($newIdSequence, ','));
 
-		// loop id's and set new sequence
-		foreach($ids as $i => $id) {
-			$item['id'] = $id;
-			$item['sequence'] = $i + 1;
+        // loop id's and set new sequence
+        foreach ($ids as $i => $id) {
+            $item['id'] = $id;
+            $item['sequence'] = $i + 1;
 
-			// update sequence
-			if(BackendCatalogModel::existsBrand($id)) BackendCatalogModel::updateBrand($item);
-		}
+            // update sequence
+            if (BackendCatalogModel::existsBrand($id)) {
+                BackendCatalogModel::updateBrand($item);
+            }
+        }
 
-		// success output
-		$this->output(self::OK, null, 'sequence updated');
-	}
+        // success output
+        $this->output(self::OK, null, 'sequence updated');
+    }
 }

--- a/src/Backend/Modules/Catalog/Ajax/SequenceCategories.php
+++ b/src/Backend/Modules/Catalog/Ajax/SequenceCategories.php
@@ -20,26 +20,28 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class SequenceCategories extends BackendBaseAJAXAction
 {
-	public function execute()
-	{		
-		parent::execute();
-		
-		// get parameters
-		$newIdSequence = trim(\SpoonFilter::getPostValue('new_id_sequence', null, '', 'string'));
+    public function execute()
+    {
+        parent::execute();
+        
+        // get parameters
+        $newIdSequence = trim(\SpoonFilter::getPostValue('new_id_sequence', null, '', 'string'));
 
-		// list id
-		$ids = (array) explode(',', rtrim($newIdSequence, ','));
+        // list id
+        $ids = (array) explode(',', rtrim($newIdSequence, ','));
 
-		// loop id's and set new sequence
-		foreach($ids as $i => $id) {
-			$item['id'] = $id;
-			$item['sequence'] = $i + 1;
+        // loop id's and set new sequence
+        foreach ($ids as $i => $id) {
+            $item['id'] = $id;
+            $item['sequence'] = $i + 1;
 
-			// update sequence
-			if(BackendCatalogModel::existsCategory($id)) BackendCatalogModel::updateCategory($item);
-		}
+            // update sequence
+            if (BackendCatalogModel::existsCategory($id)) {
+                BackendCatalogModel::updateCategory($item);
+            }
+        }
 
-		// success output
-		$this->output(self::OK, null, 'sequence updated');
-	}
+        // success output
+        $this->output(self::OK, null, 'sequence updated');
+    }
 }

--- a/src/Backend/Modules/Catalog/Ajax/SequenceMediaImages.php
+++ b/src/Backend/Modules/Catalog/Ajax/SequenceMediaImages.php
@@ -20,33 +20,35 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class SequenceMediaImages extends BackendBaseAJAXAction
 {
-	/**
-	 * Execute the action
-	 */
-	public function execute()
-	{
-		// call parent, this will probably add some general CSS/JS or other required files
-		parent::execute();
+    /**
+     * Execute the action
+     */
+    public function execute()
+    {
+        // call parent, this will probably add some general CSS/JS or other required files
+        parent::execute();
 
-		// get parameters
-		$newIdSequence = trim(\SpoonFilter::getPostValue('new_id_sequence', null, '', 'string'));
+        // get parameters
+        $newIdSequence = trim(\SpoonFilter::getPostValue('new_id_sequence', null, '', 'string'));
 
-		// list id
-		$ids = (array) explode(',', rtrim($newIdSequence, ','));
+        // list id
+        $ids = (array) explode(',', rtrim($newIdSequence, ','));
 
-		// loop id's and set new sequence
-		foreach($ids as $i => $id) {
-			// build item
-			$item['id'] = (int) $id;
+        // loop id's and set new sequence
+        foreach ($ids as $i => $id) {
+            // build item
+            $item['id'] = (int) $id;
 
-			// change sequence
-			$item['sequence'] = $i + 1;
+            // change sequence
+            $item['sequence'] = $i + 1;
 
-			// update sequence
-			if(BackendCatalogModel::existsImage($item['id'])) BackendCatalogModel::updateImage($item);
-		}
+            // update sequence
+            if (BackendCatalogModel::existsImage($item['id'])) {
+                BackendCatalogModel::updateImage($item);
+            }
+        }
 
-		// success output
-		$this->output(self::OK, null, 'sequence updated');
-	}
+        // success output
+        $this->output(self::OK, null, 'sequence updated');
+    }
 }

--- a/src/Backend/Modules/Catalog/Ajax/SequenceSpecifications.php
+++ b/src/Backend/Modules/Catalog/Ajax/SequenceSpecifications.php
@@ -20,26 +20,28 @@ use Backend\Modules\Catalog\Engine\Model as BackendCatalogModel;
  */
 class SequenceSpecifications extends BackendBaseAJAXAction
 {
-	public function execute()
-	{		
-		parent::execute();
-		
-		// get parameters
-		$newIdSequence = trim(\SpoonFilter::getPostValue('new_id_sequence', null, '', 'string'));
+    public function execute()
+    {
+        parent::execute();
+        
+        // get parameters
+        $newIdSequence = trim(\SpoonFilter::getPostValue('new_id_sequence', null, '', 'string'));
 
-		// list id
-		$ids = (array) explode(',', rtrim($newIdSequence, ','));
+        // list id
+        $ids = (array) explode(',', rtrim($newIdSequence, ','));
 
-		// loop id's and set new sequence
-		foreach($ids as $i => $id) {
-			$item['id'] = $id;
-			$item['sequence'] = $i + 1;
+        // loop id's and set new sequence
+        foreach ($ids as $i => $id) {
+            $item['id'] = $id;
+            $item['sequence'] = $i + 1;
 
-			// update sequence
-			if(BackendCatalogModel::existsSpecification($id)) BackendCatalogModel::updateSpecification($id, $item);
-		}
-		
-		// success output
-		$this->output(self::OK, null, 'sequence updated');
-	}
+            // update sequence
+            if (BackendCatalogModel::existsSpecification($id)) {
+                BackendCatalogModel::updateSpecification($id, $item);
+            }
+        }
+        
+        // success output
+        $this->output(self::OK, null, 'sequence updated');
+    }
 }

--- a/src/Backend/Modules/Catalog/Engine/Helper.php
+++ b/src/Backend/Modules/Catalog/Engine/Helper.php
@@ -17,215 +17,227 @@ namespace Backend\Modules\Catalog\Engine;
  */
 class Helper
 {
-	
-	/**
-	 * Adds a source image and additional images according to the provided formats.
-	 * Files should not be uploaded yet
-	 *
-	 * @param SpoonFileField $filefield The formfield to upload images for.
-	 * @param string $path The path to the file.
-	 * @param string $filename The file's name.
-	 * @param array[optional] $formats The formats of the images to generate based on the source.
-	 * @return bool	Returns true if every file succeeded
-	 */
-	public static function addImages($filefield, $path, $filename, array $formats = null)
-	{
-		// check input
-		if(empty($filefield) || empty($filename)) return false;
+    /**
+     * Adds a source image and additional images according to the provided formats.
+     * Files should not be uploaded yet
+     *
+     * @param SpoonFileField $filefield The formfield to upload images for.
+     * @param string $path The path to the file.
+     * @param string $filename The file's name.
+     * @param array[optional] $formats The formats of the images to generate based on the source.
+     * @return bool	Returns true if every file succeeded
+     */
+    public static function addImages($filefield, $path, $filename, array $formats = null)
+    {
+        // check input
+        if (empty($filefield) || empty($filename)) {
+            return false;
+        }
 
-		// create the path up to the source dir
-		if(!\SpoonDirectory::exists($path . '/source')) \SpoonDirectory::create($path . '/source');
+        // create the path up to the source dir
+        if (!\SpoonDirectory::exists($path . '/source')) {
+            \SpoonDirectory::create($path . '/source');
+        }
 
-		// source path
-		$pathSource = $path . '/source';
+        // source path
+        $pathSource = $path . '/source';
 
-		try {
-			// move image
-			$success[] = $filefield->moveFile($pathSource . '/' . $filename);
+        try {
+            // move image
+            $success[] = $filefield->moveFile($pathSource . '/' . $filename);
 
-			// (re)size the image
-			self::generateImages($path, $filename, $formats);
-		} catch(Exception $e) {
-			throw new SpoonException($e->getMessage());
-		}
+            // (re)size the image
+            self::generateImages($path, $filename, $formats);
+        } catch (Exception $e) {
+            throw new SpoonException($e->getMessage());
+        }
 
-		// returns true if everything succeeded
-		return true;
-	}
+        // returns true if everything succeeded
+        return true;
+    }
 
-	/**
-	 * Generates the desired image formats based on the source image
-	 *
-	 * @param string $path The path we write the images to.
-	 * @param string $filename The name of the source file.
-	 * @param array[optional] $formats The formats of the images to generate based on the source.
-	 * @return bool	Returns true if every file succeeded
-	 */
-	public static function generateImages($path, $filename, array $formats = null)
-	{
-		// check input
-		if(empty($filename)) return false;
+    /**
+     * Generates the desired image formats based on the source image
+     *
+     * @param string $path The path we write the images to.
+     * @param string $filename The name of the source file.
+     * @param array[optional] $formats The formats of the images to generate based on the source.
+     * @return bool	Returns true if every file succeeded
+     */
+    public static function generateImages($path, $filename, array $formats = null)
+    {
+        // check input
+        if (empty($filename)) {
+            return false;
+        }
 
-		// create the path up to the source dir
-		if(!\SpoonDirectory::exists($path . '/source')) \SpoonDirectory::create($path . '/source');
+        // create the path up to the source dir
+        if (!\SpoonDirectory::exists($path . '/source')) {
+            \SpoonDirectory::create($path . '/source');
+        }
 
-		// source path
-		$pathSource = $path . '/source';
-        		
-		// formats found
-		if(!empty($formats)) {
-			// loop the formats
-			foreach($formats as $format) {
-				// create the path for this product
-				if(!\SpoonDirectory::exists($path . '/' . $format['size'])) \SpoonDirectory::create($path . '/' . $format['size']);
+        // source path
+        $pathSource = $path . '/source';
+                
+        // formats found
+        if (!empty($formats)) {
+            // loop the formats
+            foreach ($formats as $format) {
+                // create the path for this product
+                if (!\SpoonDirectory::exists($path . '/' . $format['size'])) {
+                    \SpoonDirectory::create($path . '/' . $format['size']);
+                }
 
-				// exploded format
-				$explodedFormat = explode('x', $format['size']);
+                // exploded format
+                $explodedFormat = explode('x', $format['size']);
 
-				// set enlargement/aspect ratio
-				$allowEnlargement = (isset($format['allow_enlargement'])) ? $format['allow_enlargement'] : true;
-				$forceAspectRatio = (isset($format['force_aspect_ratio'])) ? $format['force_aspect_ratio'] : true;
-								
-				// get measurements of the source file
-				$sourceDimensions = getimagesize($pathSource . '/' . $filename);
+                // set enlargement/aspect ratio
+                $allowEnlargement = (isset($format['allow_enlargement'])) ? $format['allow_enlargement'] : true;
+                $forceAspectRatio = (isset($format['force_aspect_ratio'])) ? $format['force_aspect_ratio'] : true;
+                                
+                // get measurements of the source file
+                $sourceDimensions = getimagesize($pathSource . '/' . $filename);
 
-				// source width is bigger than what it should be
-				$width = ($sourceDimensions[0] > $explodedFormat[0]) ? $explodedFormat[0] : $sourceDimensions[0];
-				$height = (isset($explodedFormat[1]) && $sourceDimensions[1] > $explodedFormat[1]) ? $explodedFormat[1] : $sourceDimensions[1];
+                // source width is bigger than what it should be
+                $width = ($sourceDimensions[0] > $explodedFormat[0]) ? $explodedFormat[0] : $sourceDimensions[0];
+                $height = (isset($explodedFormat[1]) && $sourceDimensions[1] > $explodedFormat[1]) ? $explodedFormat[1] : $sourceDimensions[1];
 
-				// check if height is empty or not
-				if(empty($height)) $height = null;
+                // check if height is empty or not
+                if (empty($height)) {
+                    $height = null;
+                }
 
-				// make a thumbnail for the provided format
-				$thumbnail = new \SpoonThumbnail($pathSource . '/' . $filename, $width, ($forceAspectRatio ? null : $height));
-				$thumbnail->setAllowEnlargement($allowEnlargement);
-				$thumbnail->setForceOriginalAspectRatio($forceAspectRatio);
-				$success[] = $thumbnail->parseToFile($path . '/' . $format['size'] . '/' . $filename);
-				unset($thumbnail);	
-			}
-		}
-	}
+                // make a thumbnail for the provided format
+                $thumbnail = new \SpoonThumbnail($pathSource . '/' . $filename, $width, ($forceAspectRatio ? null : $height));
+                $thumbnail->setAllowEnlargement($allowEnlargement);
+                $thumbnail->setForceOriginalAspectRatio($forceAspectRatio);
+                $success[] = $thumbnail->parseToFile($path . '/' . $format['size'] . '/' . $filename);
+                unset($thumbnail);
+            }
+        }
+    }
 
-	/**
-	 * Get the modules that have a slideshows hook
-	 *
-	 * @return array
-	 */
-	public static function getModules()
-	{
-		return BackendModel::getModuleSetting('slideshows', 'modules');
-	}
+    /**
+     * Get the modules that have a slideshows hook
+     *
+     * @return array
+     */
+    public static function getModules()
+    {
+        return BackendModel::getModuleSetting('slideshows', 'modules');
+    }
 
-	/**
-	 * Get the supported methods by module.
-	 *
-	 * @param string $module The module we are fetching the supported methods for.
-	 * @return array
-	 */
-	public static function getSupportedMethodsByModule($module)
-	{
-		$helperFile = FRONTEND_MODULES_PATH . '/' . $module . '/engine/slideshows.php';
-		$helperFileContents = \SpoonFile::getContent($helperFile);
-		$results = array();
+    /**
+     * Get the supported methods by module.
+     *
+     * @param string $module The module we are fetching the supported methods for.
+     * @return array
+     */
+    public static function getSupportedMethodsByModule($module)
+    {
+        $helperFile = FRONTEND_MODULES_PATH . '/' . $module . '/engine/slideshows.php';
+        $helperFileContents = \SpoonFile::getContent($helperFile);
+        $results = array();
 
-		preg_match_all('/public static function (.*)\((.*)\)/', $helperFileContents, $matches);
+        preg_match_all('/public static function (.*)\((.*)\)/', $helperFileContents, $matches);
 
-		if(isset($matches[1]) && !empty($matches[1])) {
-			foreach($matches[1] as $key => $method)
-			{
-				$results[$key]['class'] = 'Frontend' . ucwords($module) . 'SlideshowsModel';
-				$results[$key]['methods'][] = $method;
-			}
-		}
+        if (isset($matches[1]) && !empty($matches[1])) {
+            foreach ($matches[1] as $key => $method) {
+                $results[$key]['class'] = 'Frontend' . ucwords($module) . 'SlideshowsModel';
+                $results[$key]['methods'][] = $method;
+            }
+        }
 
-		return $results;
-	}
+        return $results;
+    }
 
-	/**
-	 * Get the supported methods by module as pairs.
-	 *
-	 * @param string $module The module we are fetching the supported methods for.
-	 * @return array
-	 */
-	public static function getSupportedMethodsByModuleAsPairs($module)
-	{
-		$methods = self::getSupportedMethodsByModule($module);
+    /**
+     * Get the supported methods by module as pairs.
+     *
+     * @param string $module The module we are fetching the supported methods for.
+     * @return array
+     */
+    public static function getSupportedMethodsByModuleAsPairs($module)
+    {
+        $methods = self::getSupportedMethodsByModule($module);
 
-		$results = array();
+        $results = array();
 
-		foreach($methods as $key => $item) {
-			if(is_array($item)) {
-				if(isset($item['methods'])) {
-					foreach($item['methods'] as $key => $value) {
-						$results[$item['class']][$item['class'] . '::' . $value] = $value . '()';
-					}
-				}
-			}
-		}
+        foreach ($methods as $key => $item) {
+            if (is_array($item)) {
+                if (isset($item['methods'])) {
+                    foreach ($item['methods'] as $key => $value) {
+                        $results[$item['class']][$item['class'] . '::' . $value] = $value . '()';
+                    }
+                }
+            }
+        }
 
-		return $results;
-	}
+        return $results;
+    }
 
-	/**
-	 * This is used in the ajax request to repopulate the methods dropdown on slideshow edit forms.
-	 *
-	 * @param string $module The module we are fetching the supported methods for.
-	 * @return array
-	 */
-	public static function getSupportedMethodsByModuleAsPairsString($module)
-	{
-		$methods = self::getSupportedMethodsByModule($module);
-		$results = '';
+    /**
+     * This is used in the ajax request to repopulate the methods dropdown on slideshow edit forms.
+     *
+     * @param string $module The module we are fetching the supported methods for.
+     * @return array
+     */
+    public static function getSupportedMethodsByModuleAsPairsString($module)
+    {
+        $methods = self::getSupportedMethodsByModule($module);
+        $results = '';
 
-		foreach($methods as $key => $item) {
-			if(is_array($item)) {
-				if(isset($item['methods'])) {
-					$results .= '<optgroup label="' . $item['class'] . '">' . PHP_EOL;
-					foreach($item['methods'] as $key => $value){
-						$results .= '<option value="' . $item['class'] . '::' . $value . '">' . $value . '()' . '</option>' . PHP_EOL;
-					}
+        foreach ($methods as $key => $item) {
+            if (is_array($item)) {
+                if (isset($item['methods'])) {
+                    $results .= '<optgroup label="' . $item['class'] . '">' . PHP_EOL;
+                    foreach ($item['methods'] as $key => $value) {
+                        $results .= '<option value="' . $item['class'] . '::' . $value . '">' . $value . '()' . '</option>' . PHP_EOL;
+                    }
 
-					$results .= '</optgroup>';
-				}
-			}
-		}
+                    $results .= '</optgroup>';
+                }
+            }
+        }
 
-		return $results;
-	}
+        return $results;
+    }
 
-	/**
-	 * Get the supported modules.
-	 *
-	 * @return array
-	 */
-	public static function getSupportedModules()
-	{
-		$results = array();
-		$modules = self::getModules();
+    /**
+     * Get the supported modules.
+     *
+     * @return array
+     */
+    public static function getSupportedModules()
+    {
+        $results = array();
+        $modules = self::getModules();
 
-		if(!empty($modules)) {
-			// add the modules to the results
-			foreach($modules as $module) $results[$module] = $module;
+        if (!empty($modules)) {
+            // add the modules to the results
+            foreach ($modules as $module) {
+                $results[$module] = $module;
+            }
 
-			// add an empty value to the first element of the array
-			array_unshift($results, '');
-		}
+            // add an empty value to the first element of the array
+            array_unshift($results, '');
+        }
 
-		return $results;
-	}
+        return $results;
+    }
 
-	/**
-	 * Write a slideshows helper file for the specified module
-	 *
-	 * @param string $module The module to write the helper file for.
-	 */
-	public static function writeHelperFile($module)
-	{
-		$camelcasedModule = ucwords($module);
-		$helperFile = FRONTEND_MODULES_PATH . '/' . $module . '/engine/slideshows.php';
+    /**
+     * Write a slideshows helper file for the specified module
+     *
+     * @param string $module The module to write the helper file for.
+     */
+    public static function writeHelperFile($module)
+    {
+        $camelcasedModule = ucwords($module);
+        $helperFile = FRONTEND_MODULES_PATH . '/' . $module . '/engine/slideshows.php';
 
-		if(!\SpoonFile::exists($helperFile)) {
-			$content = '<?php
+        if (!\SpoonFile::exists($helperFile)) {
+            $content = '<?php
 						class Frontend' . $camelcasedModule . 'SlideshowsModel
 						{
 							public static function getImages()
@@ -241,7 +253,7 @@ class Helper
 						}
 						';
 
-			\SpoonFile::setContent($helperFile, $content);
-		}
-	}
+            \SpoonFile::setContent($helperFile, $content);
+        }
+    }
 }

--- a/src/Backend/Modules/Catalog/Engine/Model.php
+++ b/src/Backend/Modules/Catalog/Engine/Model.php
@@ -22,20 +22,20 @@ use Backend\Modules\Tags\Engine\Model as BackendTagsModel;
  */
 class Model
 {
-	const QRY_DATAGRID_BROWSE = 'SELECT i.id, i.category_id, i.title AS title, i.sequence
+    const QRY_DATAGRID_BROWSE = 'SELECT i.id, i.category_id, i.title AS title, i.sequence
 		 FROM catalog_products AS i
 		 WHERE i.language = ?
 		 ORDER BY i.sequence ASC';
 
-	const QRY_DATAGRID_BROWSE_FOR_CATEGORY = 'SELECT
+    const QRY_DATAGRID_BROWSE_FOR_CATEGORY = 'SELECT
 			i.id, i.category_id, i.title AS title, i.sequence,
 			c.title AS category
 		 FROM catalog_products AS i
 		 INNER JOIN catalog_categories AS c ON i.category_id = c.id
-		 WHERE i.category_id = ? AND i.language = ? 
+		 WHERE i.category_id = ? AND i.language = ?
 		 ORDER BY i.sequence ASC';
 
-	const QRY_DATAGRID_BROWSE_COMMENTS = 'SELECT
+    const QRY_DATAGRID_BROWSE_COMMENTS = 'SELECT
 		 	i.id, UNIX_TIMESTAMP(i.created_on) AS created_on, i.author, i.text,
 		 	p.id AS product_id, p.title AS product_title, m.url AS product_url
 		 FROM catalog_comments AS i
@@ -46,20 +46,20 @@ class Model
 		 WHERE i.status = ? AND i.language = ?
 		 GROUP BY i.id';
 
-	const QRY_DATAGRID_BROWSE_ORDERS = 'SELECT
+    const QRY_DATAGRID_BROWSE_ORDERS = 'SELECT
 		 	i.id, i.id AS order_nr, i.status, UNIX_TIMESTAMP(i.date) AS ordered_on,
 			i.email, i.fname AS FirstName, i.lname AS LastName, i.total AS TotalPrice
 		 FROM catalog_orders AS i
 		 WHERE i.status = ?
 		 GROUP BY i.id';
 
-	const QRY_DATAGRID_BROWSE_PRODUCTS_ORDER = 'SELECT c.title, c.price, o.*, m.url
+    const QRY_DATAGRID_BROWSE_PRODUCTS_ORDER = 'SELECT c.title, c.price, o.*, m.url
 		 FROM `catalog_orders_values` AS o
 		 INNER JOIN `catalog_products` AS c ON o.product_id = c.id
 		 INNER JOIN meta AS m ON c.meta_id = m.id
 		 WHERE o.order_id = ?';
 
-	const QRY_DATAGRID_BROWSE_CATEGORIES = 'SELECT c.id, c.title, COUNT(i.id) AS num_products, c.sequence
+    const QRY_DATAGRID_BROWSE_CATEGORIES = 'SELECT c.id, c.title, COUNT(i.id) AS num_products, c.sequence
 		 FROM catalog_categories AS c
 		 LEFT OUTER JOIN catalog_products AS i
 			ON c.id = i.category_id
@@ -68,7 +68,7 @@ class Model
 		 GROUP BY c.id
 		 ORDER BY c.sequence ASC';
 
-	const QRY_DATAGRID_BROWSE_CATEGORIES_WITH_CATEGORYID = 'SELECT c.id, c.title, COUNT(i.id) AS num_products, c.sequence
+    const QRY_DATAGRID_BROWSE_CATEGORIES_WITH_CATEGORYID = 'SELECT c.id, c.title, COUNT(i.id) AS num_products, c.sequence
 		 FROM catalog_categories AS c
 		 LEFT OUTER JOIN catalog_products AS i
 			ON c.id = i.category_id
@@ -77,478 +77,479 @@ class Model
 		 GROUP BY c.id
 		 ORDER BY c.sequence ASC';
 
-	const QRY_DATAGRID_BROWSE_SPECIFICATIONS = 'SELECT c.id, c.title AS specification, c.sequence
+    const QRY_DATAGRID_BROWSE_SPECIFICATIONS = 'SELECT c.id, c.title AS specification, c.sequence
 		 FROM catalog_specifications AS c
 		 WHERE c.language = ?
 		 GROUP BY c.id
 		 ORDER BY c.sequence ASC';
 
-	const QRY_DATAGRID_BROWSE_IMAGES = 'SELECT i.id, i.product_id, i.filename, i.title, i.sequence
+    const QRY_DATAGRID_BROWSE_IMAGES = 'SELECT i.id, i.product_id, i.filename, i.title, i.sequence
 		 FROM catalog_images AS i
 		 WHERE i.product_id = ?
 		 GROUP BY i.id
          ORDER BY i.sequence ASC';
 
-	const QRY_DATAGRID_BROWSE_FILES = 'SELECT i.id, i.product_id, i.filename, i.title, i.sequence
+    const QRY_DATAGRID_BROWSE_FILES = 'SELECT i.id, i.product_id, i.filename, i.title, i.sequence
 		 FROM catalog_files AS i
 		 WHERE i.product_id = ?
 		 GROUP BY i.id
          ORDER BY i.sequence ASC';
 
-	const QRY_DATAGRID_BROWSE_VIDEOS = 'SELECT i.id, i.product_id, i.embedded_url, i.title, i.sequence
+    const QRY_DATAGRID_BROWSE_VIDEOS = 'SELECT i.id, i.product_id, i.embedded_url, i.title, i.sequence
 		 FROM catalog_videos AS i
 		 WHERE i.product_id = ?
 		 GROUP BY i.id
          ORDER BY i.sequence ASC';
 
-	const QRY_DATAGRID_BROWSE_BRANDS = 'SELECT b.id, b.title, COUNT(p.id) AS num_products, b.sequence
+    const QRY_DATAGRID_BROWSE_BRANDS = 'SELECT b.id, b.title, COUNT(p.id) AS num_products, b.sequence
 		 FROM catalog_brands AS b
 		 LEFT JOIN catalog_products AS p ON p.brand_id = b.id
 		 WHERE b.language = ?
 		 GROUP BY b.id
 		 ORDER BY b.sequence ASC';
 
-	/**
-	 * Delete a certain item
-	 *
-	 * @param int $id
-	 */
-	public static function delete($id)
-	{
-		BackendModel::getContainer()->get('database')->delete('catalog_products', 'id = ?', (int)$id);
-		BackendModel::getContainer()->get('database')->delete('catalog_specifications_values', 'product_id = ?', (int)$id);
-	}
+    /**
+     * Delete a certain item
+     *
+     * @param int $id
+     */
+    public static function delete($id)
+    {
+        BackendModel::getContainer()->get('database')->delete('catalog_products', 'id = ?', (int)$id);
+        BackendModel::getContainer()->get('database')->delete('catalog_specifications_values', 'product_id = ?', (int)$id);
+    }
 
-	/**
-	 * Delete a specific category
-	 *
-	 * @param int $id
-	 */
-	public static function deleteCategory($id)
-	{
-		$db = BackendModel::getContainer()->get('database');
-		$item = self::getCategory($id);
+    /**
+     * Delete a specific category
+     *
+     * @param int $id
+     */
+    public static function deleteCategory($id)
+    {
+        $db = BackendModel::getContainer()->get('database');
+        $item = self::getCategory($id);
 
-		if(!empty($item))
-		{
-			$db->delete('meta', 'id = ?', array($item['meta_id']));
-			$db->delete('catalog_categories', 'id = ?', array((int)$id));
-			$db->update('catalog_products', array('category_id' => null), 'category_id = ?', array((int)$id));
-		}
-	}
+        if (!empty($item)) {
+            $db->delete('meta', 'id = ?', array($item['meta_id']));
+            $db->delete('catalog_categories', 'id = ?', array((int)$id));
+            $db->update('catalog_products', array('category_id' => null), 'category_id = ?', array((int)$id));
+        }
+    }
 
-	/**
-	 * Delete a specific category
-	 *
-	 * @param int $id
-	 */
-	public static function deleteBrand($id)
-	{
-		$db = BackendModel::getContainer()->get('database');
-		$item = self::getBrand($id);
+    /**
+     * Delete a specific category
+     *
+     * @param int $id
+     */
+    public static function deleteBrand($id)
+    {
+        $db = BackendModel::getContainer()->get('database');
+        $item = self::getBrand($id);
 
-		if(!empty($item))
-		{
-			$db->delete('meta', 'id = ?', array($item['meta_id']));
-			$db->delete('catalog_brands', 'id = ?', array((int)$id));
-			$db->update('catalog_products', array('brand_id' => null), 'brand_id = ?', array((int)$id));
-		}
-	}
+        if (!empty($item)) {
+            $db->delete('meta', 'id = ?', array($item['meta_id']));
+            $db->delete('catalog_brands', 'id = ?', array((int)$id));
+            $db->update('catalog_products', array('brand_id' => null), 'brand_id = ?', array((int)$id));
+        }
+    }
 
-	/**
-	 * Deletes one or more comments
-	 *
-	 * @param array $ids The id(s) of the items(s) to delete.
-	 */
-	public static function deleteComments($ids)
-	{
-		// make sure $ids is an array
-		$ids = (array)$ids;
+    /**
+     * Deletes one or more comments
+     *
+     * @param array $ids The id(s) of the items(s) to delete.
+     */
+    public static function deleteComments($ids)
+    {
+        // make sure $ids is an array
+        $ids = (array)$ids;
 
-		// loop and cast to integers
-		foreach($ids as &$id)
-		{
-			$id = (int)$id;
-		}
+        // loop and cast to integers
+        foreach ($ids as &$id) {
+            $id = (int)$id;
+        }
 
-		// create an array with an equal amount of questionmarks as ids provided
-		$idPlaceHolders = array_fill(0, count($ids), '?');
+        // create an array with an equal amount of questionmarks as ids provided
+        $idPlaceHolders = array_fill(0, count($ids), '?');
 
-		// get db
-		$db = BackendModel::getContainer()->get('database');
+        // get db
+        $db = BackendModel::getContainer()->get('database');
 
-		// get ids
-		$itemIds = (array)$db->getColumn('SELECT i.product_id
+        // get ids
+        $itemIds = (array)$db->getColumn('SELECT i.product_id
 			 FROM catalog_comments AS i
 			 WHERE i.id IN (' . implode(', ', $idPlaceHolders) . ')', $ids);
 
-		// update record
-		$db->delete('catalog_comments', 'id IN (' . implode(', ', $idPlaceHolders) . ')', $ids);
+        // update record
+        $db->delete('catalog_comments', 'id IN (' . implode(', ', $idPlaceHolders) . ')', $ids);
 
-		// recalculate the comment count
-		if(!empty($itemIds)) self::reCalculateCommentCount($itemIds);
+        // recalculate the comment count
+        if (!empty($itemIds)) {
+            self::reCalculateCommentCount($itemIds);
+        }
 
-		// invalidate the cache for catalog
-		BackendModel::invalidateFrontendCache('catalog', BL::getWorkingLanguage());
-	}
+        // invalidate the cache for catalog
+        BackendModel::invalidateFrontendCache('catalog', BL::getWorkingLanguage());
+    }
 
-	/**
-	 * Deletes one or more orders
-	 *
-	 * @param array $ids The id(s) of the items(s) to delete.
-	 */
-	public static function deleteOrders($ids)
-	{
-		// make sure $ids is an array
-		$ids = (array)$ids;
+    /**
+     * Deletes one or more orders
+     *
+     * @param array $ids The id(s) of the items(s) to delete.
+     */
+    public static function deleteOrders($ids)
+    {
+        // make sure $ids is an array
+        $ids = (array)$ids;
 
-		// loop and cast to integers
-		foreach($ids as &$id) $id = (int)$id;
+        // loop and cast to integers
+        foreach ($ids as &$id) {
+            $id = (int)$id;
+        }
 
-		// create an array with an equal amount of questionmarks as ids provided
-		$idPlaceHolders = array_fill(0, count($ids), '?');
+        // create an array with an equal amount of questionmarks as ids provided
+        $idPlaceHolders = array_fill(0, count($ids), '?');
 
-		// get db
-		$db = BackendModel::getContainer()->get('database');
+        // get db
+        $db = BackendModel::getContainer()->get('database');
 
-		// get ids
-		$itemIds = (array)$db->getColumn('SELECT i.id
+        // get ids
+        $itemIds = (array)$db->getColumn('SELECT i.id
 			 FROM catalog_orders AS i
 			 WHERE i.id IN (' . implode(', ', $idPlaceHolders) . ')', $ids);
 
-		// update record
-		$db->delete('catalog_orders', 'id IN (' . implode(', ', $idPlaceHolders) . ')', $ids);
+        // update record
+        $db->delete('catalog_orders', 'id IN (' . implode(', ', $idPlaceHolders) . ')', $ids);
 
-		// invalidate the cache for catalog
-		BackendModel::invalidateFrontendCache('catalog', BL::getWorkingLanguage());
-	}
+        // invalidate the cache for catalog
+        BackendModel::invalidateFrontendCache('catalog', BL::getWorkingLanguage());
+    }
 
-	/**
-	 * Delete a specific specification
-	 *
-	 * @param int $id
-	 */
-	public static function deleteSpecification($id)
-	{
-		$db = BackendModel::getContainer()->get('database');
-		$item = self::getSpecification($id);
+    /**
+     * Delete a specific specification
+     *
+     * @param int $id
+     */
+    public static function deleteSpecification($id)
+    {
+        $db = BackendModel::getContainer()->get('database');
+        $item = self::getSpecification($id);
 
-		if(!empty($item))
-		{
-			$db->delete('meta', 'id = ?', array($item['meta_id']));
-			$db->delete('catalog_specifications', 'id = ?', array((int)$id));
-			$db->delete('catalog_specifications_values', 'specification_id = ?', array((int)$id));
-		}
-	}
+        if (!empty($item)) {
+            $db->delete('meta', 'id = ?', array($item['meta_id']));
+            $db->delete('catalog_specifications', 'id = ?', array((int)$id));
+            $db->delete('catalog_specifications_values', 'specification_id = ?', array((int)$id));
+        }
+    }
 
-	/**
-	 * Delete all spam
-	 */
-	public static function deleteSpamComments()
-	{
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Delete all spam
+     */
+    public static function deleteSpamComments()
+    {
+        $db = BackendModel::getContainer()->get('database');
 
-		// get ids
-		$itemIds = (array)$db->getColumn('SELECT i.product_id
+        // get ids
+        $itemIds = (array)$db->getColumn('SELECT i.product_id
 			 FROM catalog_comments AS i
 			 WHERE status = ? AND i.language = ?', array('spam', BL::getWorkingLanguage()));
 
-		// update record
-		$db->delete('catalog_comments', 'status = ? AND language = ?', array('spam', BL::getWorkingLanguage()));
+        // update record
+        $db->delete('catalog_comments', 'status = ? AND language = ?', array('spam', BL::getWorkingLanguage()));
 
-		// recalculate the comment count
-		if(!empty($itemIds)) self::reCalculateCommentCount($itemIds);
+        // recalculate the comment count
+        if (!empty($itemIds)) {
+            self::reCalculateCommentCount($itemIds);
+        }
 
-		// invalidate the cache for blog
-		BackendModel::invalidateFrontendCache('catalog', BL::getWorkingLanguage());
-	}
+        // invalidate the cache for blog
+        BackendModel::invalidateFrontendCache('catalog', BL::getWorkingLanguage());
+    }
 
-	/**
-	 * Delete all spam
-	 */
-	public static function deleteCompletedOrders()
-	{
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Delete all spam
+     */
+    public static function deleteCompletedOrders()
+    {
+        $db = BackendModel::getContainer()->get('database');
 
-		// get ids
-		$itemIds = (array)$db->getColumn('SELECT i.id
+        // get ids
+        $itemIds = (array)$db->getColumn('SELECT i.id
 			 FROM catalog_orders AS i
 			 WHERE status = ?', array('completed'));
 
-		// update record
-		$db->delete('catalog_orders', 'status = ?', array('completed'));
+        // update record
+        $db->delete('catalog_orders', 'status = ?', array('completed'));
 
-		// invalidate the cache for catalog
-		BackendModel::invalidateFrontendCache('catalog', BL::getWorkingLanguage());
-	}
+        // invalidate the cache for catalog
+        BackendModel::invalidateFrontendCache('catalog', BL::getWorkingLanguage());
+    }
 
-	/**
-	 * Delete related product
-	 *
-	 * @param int The product id
-	 * @param int [optional] The related product id
-	 */
-	public static function deleteRelatedProduct($productId, $relatedProductId = null)
-	{
-		// delete specific related product
-		if(isset($relatedProductId))
-		{
-			BackendModel::getContainer()->get('database')->delete('catalog_related_products', 'product_id = ? AND related_product_id = ?', array((int)$productId, (int)$relatedProductId));
-		}
-		else
-		{
-			// delete all related products from product
-			BackendModel::getContainer()->get('database')->delete('catalog_related_products', 'product_id = ?', array((int)$productId));
-		}
-	}
+    /**
+     * Delete related product
+     *
+     * @param int The product id
+     * @param int [optional] The related product id
+     */
+    public static function deleteRelatedProduct($productId, $relatedProductId = null)
+    {
+        // delete specific related product
+        if (isset($relatedProductId)) {
+            BackendModel::getContainer()->get('database')->delete('catalog_related_products', 'product_id = ? AND related_product_id = ?', array((int)$productId, (int)$relatedProductId));
+        } else {
+            // delete all related products from product
+            BackendModel::getContainer()->get('database')->delete('catalog_related_products', 'product_id = ?', array((int)$productId));
+        }
+    }
 
-	/**
-	 * @param array $ids
-	 */
-	public static function deleteImage(array $ids)
-	{
-		if(empty($ids)) return;
+    /**
+     * @param array $ids
+     */
+    public static function deleteImage(array $ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
 
-		foreach($ids as $id)
-		{
-			$item = self::getImage($id);
-			$product = self::get($item['product_id']);
+        foreach ($ids as $id) {
+            $item = self::getImage($id);
+            $product = self::get($item['product_id']);
 
-			// delete image reference from db
-			BackendModel::getContainer()->get('database')->delete('catalog_images', 'id = ?', array($id));
+            // delete image reference from db
+            BackendModel::getContainer()->get('database')->delete('catalog_images', 'id = ?', array($id));
 
-			// delete image from disk
-			$basePath = FRONTEND_FILES_PATH . '/catalog/' . $item['product_id'];
-			\SpoonFile::delete($basePath . '/source/' . $item['filename']);
-			\SpoonFile::delete($basePath . '/64x64/' . $item['filename']);
-			\SpoonFile::delete($basePath . '/128x128/' . $item['filename']);
-			\SpoonFile::delete($basePath . '/' . BackendModel::getModuleSetting('catalog', 'width1') . 'x' . BackendModel::getModuleSetting('catalog', 'height1') . '/' . $item['filename']);
-			\SpoonFile::delete($basePath . '/' . BackendModel::getModuleSetting('catalog', 'width2') . 'x' . BackendModel::getModuleSetting('catalog', 'height2') . '/' . $item['filename']);
-			\SpoonFile::delete($basePath . '/' . BackendModel::getModuleSetting('catalog', 'width3') . 'x' . BackendModel::getModuleSetting('catalog', 'height3') . '/' . $item['filename']);
-		}
+            // delete image from disk
+            $basePath = FRONTEND_FILES_PATH . '/catalog/' . $item['product_id'];
+            \SpoonFile::delete($basePath . '/source/' . $item['filename']);
+            \SpoonFile::delete($basePath . '/64x64/' . $item['filename']);
+            \SpoonFile::delete($basePath . '/128x128/' . $item['filename']);
+            \SpoonFile::delete($basePath . '/' . BackendModel::getModuleSetting('catalog', 'width1') . 'x' . BackendModel::getModuleSetting('catalog', 'height1') . '/' . $item['filename']);
+            \SpoonFile::delete($basePath . '/' . BackendModel::getModuleSetting('catalog', 'width2') . 'x' . BackendModel::getModuleSetting('catalog', 'height2') . '/' . $item['filename']);
+            \SpoonFile::delete($basePath . '/' . BackendModel::getModuleSetting('catalog', 'width3') . 'x' . BackendModel::getModuleSetting('catalog', 'height3') . '/' . $item['filename']);
+        }
 
-		BackendModel::invalidateFrontendCache('slideshowCache');
-	}
+        BackendModel::invalidateFrontendCache('slideshowCache');
+    }
 
-	/**
-	 * @param array $ids
-	 */
-	public static function deleteFile(array $ids)
-	{
-		if(empty($ids)) return;
+    /**
+     * @param array $ids
+     */
+    public static function deleteFile(array $ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
 
-		foreach($ids as $id)
-		{
-			$item = self::getFile($id);
-			$product = self::get($item['product_id']);
+        foreach ($ids as $id) {
+            $item = self::getFile($id);
+            $product = self::get($item['product_id']);
 
-			// delete file reference from db
-			BackendModel::getContainer()->get('database')->delete('catalog_files', 'id = ?', array($id));
+            // delete file reference from db
+            BackendModel::getContainer()->get('database')->delete('catalog_files', 'id = ?', array($id));
 
-			// delete file from disk
-			$basePath = FRONTEND_FILES_PATH . '/catalog/' . $item['product_id'];
-			\SpoonFile::delete($basePath . '/source/' . $item['filename']);
-		}
-	}
+            // delete file from disk
+            $basePath = FRONTEND_FILES_PATH . '/catalog/' . $item['product_id'];
+            \SpoonFile::delete($basePath . '/source/' . $item['filename']);
+        }
+    }
 
-	/**
-	 * @param array $ids
-	 */
-	public static function deleteVideo(array $ids)
-	{
-		if(empty($ids)) return;
+    /**
+     * @param array $ids
+     */
+    public static function deleteVideo(array $ids)
+    {
+        if (empty($ids)) {
+            return;
+        }
 
-		foreach($ids as $id)
-		{
-			$item = self::getVideo($id);
-			$product = self::get($item['product_id']);
+        foreach ($ids as $id) {
+            $item = self::getVideo($id);
+            $product = self::get($item['product_id']);
 
-			// delete video reference from db
-			BackendModel::getContainer()->get('database')->delete('catalog_videos', 'id = ?', array($id));
-		}
-	}
+            // delete video reference from db
+            BackendModel::getContainer()->get('database')->delete('catalog_videos', 'id = ?', array($id));
+        }
+    }
 
-	/**
-	 * Checks if a certain item exists
-	 *
-	 * @param int $id
-	 * @return bool
-	 */
-	public static function exists($id)
-	{
-		return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
+    /**
+     * Checks if a certain item exists
+     *
+     * @param int $id
+     * @return bool
+     */
+    public static function exists($id)
+    {
+        return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
 			 FROM catalog_products AS i
 			 WHERE i.id = ?
 			 LIMIT 1', array((int)$id));
-	}
+    }
 
-	/**
-	 * Does the category exist?
-	 *
-	 * @param int $id
-	 * @return bool
-	 */
-	public static function existsCategory($id)
-	{
-		return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
+    /**
+     * Does the category exist?
+     *
+     * @param int $id
+     * @return bool
+     */
+    public static function existsCategory($id)
+    {
+        return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
 			 FROM catalog_categories AS i
 			 WHERE i.id = ? AND i.language = ?
 			 LIMIT 1', array((int)$id, BL::getWorkingLanguage()));
-	}
+    }
 
-	/**
-	 * Checks if a comment exists
-	 *
-	 * @param int $id The id of the item to check for existence.
-	 * @return int
-	 */
-	public static function existsComment($id)
-	{
-		return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
+    /**
+     * Checks if a comment exists
+     *
+     * @param int $id The id of the item to check for existence.
+     * @return int
+     */
+    public static function existsComment($id)
+    {
+        return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
 			 FROM catalog_comments AS i
 			 WHERE i.id = ? AND i.language = ?
 			 LIMIT 1', array((int)$id, BL::getWorkingLanguage()));
-	}
+    }
 
-	/**
-	 * Checks if a order exists
-	 *
-	 * @param int $id The id of the item to check for existence.
-	 * @return int
-	 */
-	public static function existsOrder($id)
-	{
-		return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
+    /**
+     * Checks if a order exists
+     *
+     * @param int $id The id of the item to check for existence.
+     * @return int
+     */
+    public static function existsOrder($id)
+    {
+        return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
 			 FROM catalog_orders AS i
 			 WHERE i.id = ?
 			 LIMIT 1', array((int)$id));
-	}
+    }
 
-	/**
-	 * Checks if specification exists
-	 *
-	 * @param int $id Id of a specification.
-	 * @param int [optional] $productId Id of a product.
-	 * @return bool
-	 */
-	public static function existsSpecification($id)
-	{
-		return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
+    /**
+     * Checks if specification exists
+     *
+     * @param int $id Id of a specification.
+     * @param int [optional] $productId Id of a product.
+     * @return bool
+     */
+    public static function existsSpecification($id)
+    {
+        return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
 			 FROM catalog_specifications AS i
 			 WHERE i.id = ? AND i.language = ?
 			 LIMIT 1', array((int)$id, BL::getWorkingLanguage()));
-	}
+    }
 
-	/**
-	 * Checks if value of specification exists
-	 *
-	 * @param int $id Id of a specification.
-	 * @param int [optional] $productId Id of a product.
-	 * @return bool
-	 */
-	public static function existsSpecificationValue($productId, $specificationId)
-	{
-		return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
+    /**
+     * Checks if value of specification exists
+     *
+     * @param int $id Id of a specification.
+     * @param int [optional] $productId Id of a product.
+     * @return bool
+     */
+    public static function existsSpecificationValue($productId, $specificationId)
+    {
+        return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
 			 FROM catalog_specifications_values AS i
-			 WHERE i.product_id = ? AND i.specification_id = ? 
+			 WHERE i.product_id = ? AND i.specification_id = ?
 			 LIMIT 1', array((int)$productId, (int)$specificationId));
-	}
+    }
 
-	/**
-	 * Checks if image exists
-	 *
-	 * @param int $id
-	 * @return bool
-	 */
-	public static function existsImage($id)
-	{
-		return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
+    /**
+     * Checks if image exists
+     *
+     * @param int $id
+     * @return bool
+     */
+    public static function existsImage($id)
+    {
+        return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
 			 FROM catalog_images AS a
 			 WHERE a.id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Checks if file exists
-	 *
-	 * @param int $id
-	 * @return bool
-	 */
-	public static function existsFile($id)
-	{
-		return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
+    /**
+     * Checks if file exists
+     *
+     * @param int $id
+     * @return bool
+     */
+    public static function existsFile($id)
+    {
+        return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
 			 FROM catalog_files AS a
 			 WHERE a.id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Checks if video exists
-	 *
-	 * @param int $id
-	 * @return bool
-	 */
-	public static function existsVideo($id)
-	{
-		return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
+    /**
+     * Checks if video exists
+     *
+     * @param int $id
+     * @return bool
+     */
+    public static function existsVideo($id)
+    {
+        return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
 			 FROM catalog_videos AS a
 			 WHERE a.id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Does the category exist?
-	 *
-	 * @param int $id
-	 * @return bool
-	 */
-	public static function existsBrand($id)
-	{
-		return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
+    /**
+     * Does the category exist?
+     *
+     * @param int $id
+     * @return bool
+     */
+    public static function existsBrand($id)
+    {
+        return (bool)BackendModel::getContainer()->get('database')->getVar('SELECT 1
 			 FROM catalog_brands AS i
 			 WHERE i.id = ?
 			 LIMIT 1', array((int)$id));
-	}
+    }
 
-	/**
-	 * Fetches a certain item
-	 *
-	 * @param int $id
-	 * @return array
-	 */
-	public static function get($id)
-	{
-		return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
+    /**
+     * Fetches a certain item
+     *
+     * @param int $id
+     * @return array
+     */
+    public static function get($id)
+    {
+        return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
 			 FROM catalog_products AS i
 			 WHERE i.id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Fetches a all items
-	 *
-	 * @param int $id
-	 * @return array
-	 */
-	public static function getAll()
-	{
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Fetches a all items
+     *
+     * @param int $id
+     * @return array
+     */
+    public static function getAll()
+    {
+        $db = BackendModel::getContainer()->get('database');
 
-		return (array)$db->getPairs('SELECT i.id, i.title
+        return (array)$db->getPairs('SELECT i.id, i.title
 			 FROM catalog_products AS i
 			 WHERE i.language = ?
 			 GROUP BY i.id', array(BL::getWorkingLanguage()));
-	}
+    }
 
-	/**
-	 * Get all the categories
-	 *
-	 * @param bool [optional] $includeCount
-	 * @return array
-	 */
-	public static function getCategories($includeCount = false)
-	{
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Get all the categories
+     *
+     * @param bool [optional] $includeCount
+     * @return array
+     */
+    public static function getCategories($includeCount = false)
+    {
+        $db = BackendModel::getContainer()->get('database');
 
-		if($includeCount)
-		{
-			$allCategories = (array)$db->getRecords('SELECT i.id, i.parent_id, CONCAT(i.title, " (", COUNT(p.category_id) ,")") AS title
+        if ($includeCount) {
+            $allCategories = (array)$db->getRecords('SELECT i.id, i.parent_id, CONCAT(i.title, " (", COUNT(p.category_id) ,")") AS title
 				 FROM catalog_categories AS i
 				 LEFT OUTER JOIN catalog_products AS p ON i.id = p.category_id AND i.language = p.language
 				 WHERE i.language = ?
@@ -556,1032 +557,995 @@ class Model
 				 ORDER BY i.sequence', array(BL::getWorkingLanguage()));
 
 
-			$tree = array();
+            $tree = array();
 
-			$categoryTree = self::buildTree($tree, $allCategories);
-			$categoryTree = array('no_category' => ucfirst(BL::getLabel('None'))) + $categoryTree;
+            $categoryTree = self::buildTree($tree, $allCategories);
+            $categoryTree = array('no_category' => ucfirst(BL::getLabel('None'))) + $categoryTree;
 
-			return $categoryTree;
-		}
-	}
+            return $categoryTree;
+        }
+    }
 
-	/**
-	 * Build the category tree
-	 *
-	 * @param $tree
-	 * @param array $categories
-	 * @param int $parentId
-	 * @param int $level
-	 * @return array
-	 */
-	public static function buildTree(array &$tree, array $categories, $parentId = 0, $level = 0)
-	{
-		foreach($categories as $category)
-		{
-			if($category['parent_id'] == $parentId)
-			{
-				$tree[$category['id']] = str_repeat('-', $level) . $category['title'];
+    /**
+     * Build the category tree
+     *
+     * @param $tree
+     * @param array $categories
+     * @param int $parentId
+     * @param int $level
+     * @return array
+     */
+    public static function buildTree(array &$tree, array $categories, $parentId = 0, $level = 0)
+    {
+        foreach ($categories as $category) {
+            if ($category['parent_id'] == $parentId) {
+                $tree[$category['id']] = str_repeat('-', $level) . $category['title'];
 
-				$level++;
-				$children = self::buildTree($tree, $categories, $category['id'], $level);
-				$level--;
-			}
-		}
-		return $tree;
-	}
+                $level++;
+                $children = self::buildTree($tree, $categories, $category['id'], $level);
+                $level--;
+            }
+        }
+        return $tree;
+    }
 
-	/**
-	 * Get all data for a given id
-	 *
-	 * @param int $id The Id of the comment to fetch?
-	 * @return array
-	 */
-	public static function getComment($id)
-	{
-		return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*, UNIX_TIMESTAMP(i.created_on) AS created_on,
+    /**
+     * Get all data for a given id
+     *
+     * @param int $id The Id of the comment to fetch?
+     * @return array
+     */
+    public static function getComment($id)
+    {
+        return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*, UNIX_TIMESTAMP(i.created_on) AS created_on,
 			 p.id AS product_id, p.title AS product_title, m.url AS product_url
 			 FROM catalog_comments AS i
 			 INNER JOIN catalog_products AS p ON i.product_id = p.id AND i.language = p.language
 			 INNER JOIN meta AS m ON p.meta_id = m.id
 			 WHERE i.id = ?
 			 LIMIT 1', array((int)$id));
-	}
+    }
 
-	/**
-	 * Get all data for a given id
-	 *
-	 * @param int $id The Id of the order to fetch?
-	 * @return array
-	 */
-	public static function getOrder($id)
-	{
-		return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*, UNIX_TIMESTAMP(i.date) AS ordered_on,
+    /**
+     * Get all data for a given id
+     *
+     * @param int $id The Id of the order to fetch?
+     * @return array
+     */
+    public static function getOrder($id)
+    {
+        return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*, UNIX_TIMESTAMP(i.date) AS ordered_on,
 			 p.amount AS amount_of_product, c.title AS product_title
 			 FROM catalog_orders AS i
 			 INNER JOIN catalog_orders_values AS p ON i.id = p.order_id
 			 INNER JOIN catalog_products AS c ON p.product_id = c.id
 			 WHERE i.id = ?
 			 LIMIT 1', array((int)$id));
-	}
+    }
 
-	/**
-	 * Get multiple comments at once
-	 *
-	 * @param array $ids The id(s) of the comment(s).
-	 * @return array
-	 */
-	public static function getComments(array $ids)
-	{
-		return (array)BackendModel::getContainer()->get('database')->getRecords('SELECT *
+    /**
+     * Get multiple comments at once
+     *
+     * @param array $ids The id(s) of the comment(s).
+     * @return array
+     */
+    public static function getComments(array $ids)
+    {
+        return (array)BackendModel::getContainer()->get('database')->getRecords('SELECT *
 			 FROM catalog_comments AS i
 			 WHERE i.id IN (' . implode(', ', array_fill(0, count($ids), '?')) . ')', $ids);
-	}
+    }
 
-	/**
-	 * Get a count per comment
-	 *
-	 * @return array
-	 */
-	public static function getCommentStatusCount()
-	{
-		return (array)BackendModel::getContainer()->get('database')->getPairs('SELECT i.status, COUNT(i.id)
+    /**
+     * Get a count per comment
+     *
+     * @return array
+     */
+    public static function getCommentStatusCount()
+    {
+        return (array)BackendModel::getContainer()->get('database')->getPairs('SELECT i.status, COUNT(i.id)
 			 FROM catalog_comments AS i
 			 WHERE i.language = ?
 			 GROUP BY i.status', array(BL::getWorkingLanguage()));
-	}
+    }
 
-	/**
-	 * Get all products grouped by categories
-	 *
-	 * @return array
-	 */
-	public static function getAllProductsGroupedByCategories()
-	{
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Get all products grouped by categories
+     *
+     * @return array
+     */
+    public static function getAllProductsGroupedByCategories()
+    {
+        $db = BackendModel::getContainer()->get('database');
 
-		$allProducts = (array)$db->getRecords('SELECT p.id, p.title, pc.id AS category_id, pc.title AS category_title
+        $allProducts = (array)$db->getRecords('SELECT p.id, p.title, pc.id AS category_id, pc.title AS category_title
 			 FROM catalog_products p
 			 INNER JOIN catalog_categories pc ON p.category_id = pc.id
 			 WHERE p.language = ?', array(BL::getWorkingLanguage()));
 
-		$productsGroupedByCategory = array();
+        $productsGroupedByCategory = array();
 
-		foreach($allProducts as $pid => $product)
-		{
-			$productsGroupedByCategory[$product['category_title']][$product['id']] = $product['title'];
-		}
+        foreach ($allProducts as $pid => $product) {
+            $productsGroupedByCategory[$product['category_title']][$product['id']] = $product['title'];
+        }
 
-		return $productsGroupedByCategory;
-	}
+        return $productsGroupedByCategory;
+    }
 
-	/**
-	 * Get related products of an item
-	 *
-	 * @param int $id The product id
-	 * @return array
-	 */
-	public static function getRelatedProducts($id)
-	{
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Get related products of an item
+     *
+     * @param int $id The product id
+     * @return array
+     */
+    public static function getRelatedProducts($id)
+    {
+        $db = BackendModel::getContainer()->get('database');
 
-		$relatedProducts = (array)$db->getPairs('SELECT r.related_product_id AS keyId, r.related_product_id AS valueId
+        $relatedProducts = (array)$db->getPairs('SELECT r.related_product_id AS keyId, r.related_product_id AS valueId
 			 FROM catalog_related_products r
 			 WHERE r.product_id = ?', array((int)$id));
 
-		$i = 0;
+        $i = 0;
 
-		// build new keys (starting from zero)	
-		foreach($relatedProducts as $key => $value)
-		{
-			if(isset($relatedProducts[$key]))
-			{
-				$relatedProducts[$i] = $relatedProducts[$key];
-				unset($relatedProducts[$key]);
-			}
-			$i++;
-		}
+        // build new keys (starting from zero)
+        foreach ($relatedProducts as $key => $value) {
+            if (isset($relatedProducts[$key])) {
+                $relatedProducts[$i] = $relatedProducts[$key];
+                unset($relatedProducts[$key]);
+            }
+            $i++;
+        }
 
-		return $relatedProducts;
-	}
+        return $relatedProducts;
+    }
 
-	/**
-	 * Get specification value of an item
-	 *
-	 * @param int $specificationId The specification id
-	 * @param int $productId The product id
-	 * @return string
-	 */
-	public static function getSpecificationValue($specificationId, $productId)
-	{
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Get specification value of an item
+     *
+     * @param int $specificationId The specification id
+     * @param int $productId The product id
+     * @return string
+     */
+    public static function getSpecificationValue($specificationId, $productId)
+    {
+        $db = BackendModel::getContainer()->get('database');
 
-		$value = (array)$db->getRecord('SELECT i.value
+        $value = (array)$db->getRecord('SELECT i.value
 			 FROM catalog_specifications_values i
 			 WHERE i.specification_id = ? AND i.product_id = ?', array((int)$specificationId, (int)$productId));
 
-		return $value;
-	}
+        return $value;
+    }
 
-	/**
-	 * Fetch an image
-	 *
-	 * @param int $id
-	 * @return array
-	 */
-	public static function getImage($id)
-	{
-		return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
+    /**
+     * Fetch an image
+     *
+     * @param int $id
+     * @return array
+     */
+    public static function getImage($id)
+    {
+        return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
 			 FROM catalog_images AS i
 			 WHERE i.id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Fetch an file
-	 *
-	 * @param int $id
-	 * @return array
-	 */
-	public static function getFile($id)
-	{
-		return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
+    /**
+     * Fetch an file
+     *
+     * @param int $id
+     * @return array
+     */
+    public static function getFile($id)
+    {
+        return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
 			 FROM catalog_files AS i
 			 WHERE i.id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Fetch an video
-	 *
-	 * @param int $id
-	 * @return array
-	 */
-	public static function getVideo($id)
-	{
-		return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
+    /**
+     * Fetch an video
+     *
+     * @param int $id
+     * @return array
+     */
+    public static function getVideo($id)
+    {
+        return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
 			 FROM catalog_videos AS i
 			 WHERE i.id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Check if category has children
-	 *
-	 * @param int $id
-	 * @return bool
-	 */
-	public static function categoryHasChildren($id)
-	{
-		// gives children from category
-		$item = (array)BackendModel::getContainer()->get('database')->getRecord('SELECT c1.id as childID, c1.title ChildName, c2.title as ParentName
+    /**
+     * Check if category has children
+     *
+     * @param int $id
+     * @return bool
+     */
+    public static function categoryHasChildren($id)
+    {
+        // gives children from category
+        $item = (array)BackendModel::getContainer()->get('database')->getRecord('SELECT c1.id as childID, c1.title ChildName, c2.title as ParentName
 			 FROM catalog_categories AS c1
 			 LEFT OUTER JOIN catalog_categories AS c2 ON c1.id = c2.parent_id
 			 WHERE c1.language = ? AND c1.parent_id = ?', array(BL::getWorkingLanguage(), $id));
 
-		if($item == null)
-		{
-			return false;
-		}
-		else
-		{
-			return true;
-		}
-	}
+        if ($item == null) {
+            return false;
+        } else {
+            return true;
+        }
+    }
 
-	/**
-	 * Fetch a category
-	 *
-	 * @param int $id
-	 * @return array
-	 */
-	public static function getCategory($id)
-	{
-		return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
+    /**
+     * Fetch a category
+     *
+     * @param int $id
+     * @return array
+     */
+    public static function getCategory($id)
+    {
+        return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
 			 FROM catalog_categories AS i
 			 WHERE i.id = ? AND i.language = ?', array((int)$id, BL::getWorkingLanguage()));
-	}
+    }
 
-	/**
-	 * Fetch a specification
-	 *
-	 * @param int $id
-	 * @return array
-	 */
-	public static function getSpecification($id)
-	{
-		return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
+    /**
+     * Fetch a specification
+     *
+     * @param int $id
+     * @return array
+     */
+    public static function getSpecification($id)
+    {
+        return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
 			 FROM catalog_specifications AS i
 			 WHERE i.id = ? AND i.language = ?', array((int)$id, BL::getWorkingLanguage()));
-	}
+    }
 
-	/**
-	 * Get the maximum sequence for a category
-	 *
-	 * @return int
-	 */
-	public static function getMaximumCategorySequence()
-	{
-		return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
+    /**
+     * Get the maximum sequence for a category
+     *
+     * @return int
+     */
+    public static function getMaximumCategorySequence()
+    {
+        return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
 			 FROM catalog_categories AS i
 			 WHERE i.language = ?', array(BL::getWorkingLanguage()));
-	}
+    }
 
-	/**
-	 * Get the maximum sequence for a specification
-	 *
-	 * @return int
-	 */
-	public static function getMaximumSpecificationSequence()
-	{
-		return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
+    /**
+     * Get the maximum sequence for a specification
+     *
+     * @return int
+     */
+    public static function getMaximumSpecificationSequence()
+    {
+        return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
 			 FROM catalog_specifications AS i
 			 WHERE i.language = ?', array(BL::getWorkingLanguage()));
-	}
+    }
 
-	/**
-	 * Get the max sequence id for an image
-	 *
-	 * @param int $id The product id.
-	 * @return int
-	 */
-	public static function getMaximumImagesSequence($id)
-	{
-		return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
+    /**
+     * Get the max sequence id for an image
+     *
+     * @param int $id The product id.
+     * @return int
+     */
+    public static function getMaximumImagesSequence($id)
+    {
+        return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
 			 FROM catalog_images AS i
 			 WHERE i.product_id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Get the max sequence id for an file
-	 *
-	 * @param int $id The product id.
-	 * @return int
-	 */
-	public static function getMaximumFilesSequence($id)
-	{
-		return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
+    /**
+     * Get the max sequence id for an file
+     *
+     * @param int $id The product id.
+     * @return int
+     */
+    public static function getMaximumFilesSequence($id)
+    {
+        return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
 			 FROM catalog_files AS i
 			 WHERE i.product_id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Get the max sequence id for an videos
-	 *
-	 * @param int $id The product id.
-	 * @return int
-	 */
-	public static function getMaximumVideosSequence($id)
-	{
-		return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
+    /**
+     * Get the max sequence id for an videos
+     *
+     * @param int $id The product id.
+     * @return int
+     */
+    public static function getMaximumVideosSequence($id)
+    {
+        return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
 			 FROM catalog_videos AS i
 			 WHERE i.product_id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Get the maximum sequence
-	 *
-	 * @return int
-	 */
-	public static function getMaximumSequence()
-	{
-		return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
+    /**
+     * Get the maximum sequence
+     *
+     * @return int
+     */
+    public static function getMaximumSequence()
+    {
+        return (int)BackendModel::getContainer()->get('database')->getVar('SELECT MAX(i.sequence)
 			 FROM catalog_products AS i');
-	}
+    }
 
-	/**
-	 * Get all the specifications
-	 *
-	 * @return array
-	 */
-	public static function getSpecifications()
-	{
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Get all the specifications
+     *
+     * @return array
+     */
+    public static function getSpecifications()
+    {
+        $db = BackendModel::getContainer()->get('database');
 
-		$items = (array)$db->getRecords('SELECT i.id, i.title, i.type
+        $items = (array)$db->getRecords('SELECT i.id, i.title, i.type
 			 FROM catalog_specifications AS i
 			 WHERE i.language = ?
 			 GROUP BY i.id
 			 ORDER BY i.sequence', array(BL::getWorkingLanguage()));
 
-		return $items;
-	}
+        return $items;
+    }
 
-	/**
-	 * Get all the specifications
-	 *
-	 * @return array
-	 */
-	public static function getBrandsForDropdown()
-	{
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Get all the specifications
+     *
+     * @return array
+     */
+    public static function getBrandsForDropdown()
+    {
+        $db = BackendModel::getContainer()->get('database');
 
-		$items = (array)$db->getPairs('SELECT i.id, i.title
+        $items = (array)$db->getPairs('SELECT i.id, i.title
 			 FROM catalog_brands AS i
 			 WHERE i.language = ?
 			 GROUP BY i.id
 			 ORDER BY i.sequence',
              array(BL::getWorkingLanguage()));
 
-		return $items;
-	}
+        return $items;
+    }
 
-	/**
-	 * Fetch a category
-	 *
-	 * @param int $id
-	 * @return array
-	 */
-	public static function getBrand($id)
-	{
-		return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
+    /**
+     * Fetch a category
+     *
+     * @param int $id
+     * @return array
+     */
+    public static function getBrand($id)
+    {
+        return (array)BackendModel::getContainer()->get('database')->getRecord('SELECT i.*
 			 FROM catalog_brands AS i
 			 WHERE i.id = ?', array((int)$id));
-	}
+    }
 
-	/**
-	 * Retrieve the unique URL for an item
-	 *
-	 * @param string $url
-	 * @param int [optional] $id    The id of the item to ignore.
-	 * @return string
-	 */
-	public static function getURL($url, $id = null)
-	{
-		$url = \SpoonFilter::urlise((string)$url);
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Retrieve the unique URL for an item
+     *
+     * @param string $url
+     * @param int [optional] $id    The id of the item to ignore.
+     * @return string
+     */
+    public static function getURL($url, $id = null)
+    {
+        $url = \SpoonFilter::urlise((string)$url);
+        $db = BackendModel::getContainer()->get('database');
 
-		// new item
-		if($id === null)
-		{
-			// already exists
-			if((bool)$db->getVar('SELECT 1
+        // new item
+        if ($id === null) {
+            // already exists
+            if ((bool)$db->getVar('SELECT 1
 				 FROM catalog_products AS i
 				 INNER JOIN meta AS m ON i.meta_id = m.id
 				 WHERE i.language = ? AND m.url = ?
 				 LIMIT 1', array(BL::getWorkingLanguage(), $url))
-			)
-			{
-				$url = BackendModel::addNumber($url);
-				return self::getURL($url);
-			}
-		}
-		else
-		{
-			// current item should be excluded
-			// already exists
-			if((bool)$db->getVar('SELECT 1
+            ) {
+                $url = BackendModel::addNumber($url);
+                return self::getURL($url);
+            }
+        } else {
+            // current item should be excluded
+            // already exists
+            if ((bool)$db->getVar('SELECT 1
 				 FROM catalog_products AS i
 				 INNER JOIN meta AS m ON i.meta_id = m.id
 				 WHERE i.language = ? AND m.url = ? AND i.id != ?
 				 LIMIT 1', array(BL::getWorkingLanguage(), $url, $id))
-			)
-			{
-				$url = BackendModel::addNumber($url);
-				return self::getURL($url, $id);
-			}
-		}
+            ) {
+                $url = BackendModel::addNumber($url);
+                return self::getURL($url, $id);
+            }
+        }
 
-		return $url;
-	}
+        return $url;
+    }
 
-	/**
-	 * Retrieve the unique URL for a specification
-	 *
-	 * @param string $url
-	 * @param int [optional] $id The id of the specification to ignore.
-	 * @return string
-	 */
-	public static function getURLForSpecification($url, $id = null)
-	{
-		$url = \SpoonFilter::urlise((string)$url);
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Retrieve the unique URL for a specification
+     *
+     * @param string $url
+     * @param int [optional] $id The id of the specification to ignore.
+     * @return string
+     */
+    public static function getURLForSpecification($url, $id = null)
+    {
+        $url = \SpoonFilter::urlise((string)$url);
+        $db = BackendModel::getContainer()->get('database');
 
-		// new specification
-		if($id === null)
-		{
-			if((bool)$db->getVar('SELECT 1
+        // new specification
+        if ($id === null) {
+            if ((bool)$db->getVar('SELECT 1
 				 FROM catalog_specifications AS i
 				 INNER JOIN meta AS m ON i.meta_id = m.id
 				 WHERE i.language = ? AND m.url = ?
 				 LIMIT 1', array(BL::getWorkingLanguage(), $url))
-			)
-			{
-				$url = BackendModel::addNumber($url);
-				return self::getURLForSpecification($url);
-			}
-		}
+            ) {
+                $url = BackendModel::addNumber($url);
+                return self::getURLForSpecification($url);
+            }
+        }
 
-		// current specification should be excluded
-		else
-		{
-			if((bool)$db->getVar('SELECT 1
+        // current specification should be excluded
+        else {
+            if ((bool)$db->getVar('SELECT 1
 				 FROM catalog_specifications AS i
 				 INNER JOIN meta AS m ON i.meta_id = m.id
 				 WHERE i.language = ? AND m.url = ? AND i.id != ?
 				 LIMIT 1', array(BL::getWorkingLanguage(), $url, $id))
-			)
-			{
-				$url = BackendModel::addNumber($url);
-				return self::getURLForSpecification($url, $id);
-			}
-		}
+            ) {
+                $url = BackendModel::addNumber($url);
+                return self::getURLForSpecification($url, $id);
+            }
+        }
 
-		return $url;
-	}
+        return $url;
+    }
 
-	/**
-	 * Retrieve the unique URL for a category
-	 *
-	 * @param string $url
-	 * @param int [optional] $id The id of the category to ignore.
-	 * @return string
-	 */
-	public static function getURLForCategory($url, $id = null)
-	{
-		$url = \SpoonFilter::urlise((string)$url);
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Retrieve the unique URL for a category
+     *
+     * @param string $url
+     * @param int [optional] $id The id of the category to ignore.
+     * @return string
+     */
+    public static function getURLForCategory($url, $id = null)
+    {
+        $url = \SpoonFilter::urlise((string)$url);
+        $db = BackendModel::getContainer()->get('database');
 
-		// new category
-		if($id === null)
-		{
-			if((bool)$db->getVar('SELECT 1
+        // new category
+        if ($id === null) {
+            if ((bool)$db->getVar('SELECT 1
 				 FROM catalog_categories AS i
 				 INNER JOIN meta AS m ON i.meta_id = m.id
 				 WHERE i.language = ? AND m.url = ?
 				 LIMIT 1', array(BL::getWorkingLanguage(), $url))
-			)
-			{
-				$url = BackendModel::addNumber($url);
-				return self::getURLForCategory($url);
-			}
-		}
-		else
-		{
-			// current category should be excluded
-			if((bool)$db->getVar('SELECT 1
+            ) {
+                $url = BackendModel::addNumber($url);
+                return self::getURLForCategory($url);
+            }
+        } else {
+            // current category should be excluded
+            if ((bool)$db->getVar('SELECT 1
 				 FROM catalog_categories AS i
 				 INNER JOIN meta AS m ON i.meta_id = m.id
 				 WHERE i.language = ? AND m.url = ? AND i.id != ?
 				 LIMIT 1', array(BL::getWorkingLanguage(), $url, $id))
-			)
-			{
-				$url = BackendModel::addNumber($url);
-				return self::getURLForCategory($url, $id);
-			}
-		}
+            ) {
+                $url = BackendModel::addNumber($url);
+                return self::getURLForCategory($url, $id);
+            }
+        }
 
-		return $url;
-	}
+        return $url;
+    }
 
-	/**
-	 * Retrieve the unique URL for a category
-	 *
-	 * @param string $url
-	 * @param int [optional] $id The id of the category to ignore.
-	 * @return string
-	 */
-	public static function getURLForBrand($url, $id = null)
-	{
-		$url = \SpoonFilter::urlise((string)$url);
-		$db = BackendModel::getContainer()->get('database');
+    /**
+     * Retrieve the unique URL for a category
+     *
+     * @param string $url
+     * @param int [optional] $id The id of the category to ignore.
+     * @return string
+     */
+    public static function getURLForBrand($url, $id = null)
+    {
+        $url = \SpoonFilter::urlise((string)$url);
+        $db = BackendModel::getContainer()->get('database');
 
-		// new category
-		if($id === null)
-		{
-			if((bool)$db->getVar('SELECT 1
+        // new category
+        if ($id === null) {
+            if ((bool)$db->getVar('SELECT 1
 				 FROM catalog_brands AS i
 				 INNER JOIN meta AS m ON i.meta_id = m.id
 				 WHERE m.url = ?
 				 LIMIT 1', array($url))
-			)
-			{
-				$url = BackendModel::addNumber($url);
-				return self::getURLForCategory($url);
-			}
-		}
-		else
-		{
-			// current category should be excluded
-			if((bool)$db->getVar('SELECT 1
+            ) {
+                $url = BackendModel::addNumber($url);
+                return self::getURLForCategory($url);
+            }
+        } else {
+            // current category should be excluded
+            if ((bool)$db->getVar('SELECT 1
 				 FROM catalog_brands AS i
 				 INNER JOIN meta AS m ON i.meta_id = m.id
 				 WHERE m.url = ? AND i.id != ?
 				 LIMIT 1', array($url, $id))
-			)
-			{
-				$url = BackendModel::addNumber($url);
-				return self::getURLForCategory($url, $id);
-			}
-		}
+            ) {
+                $url = BackendModel::addNumber($url);
+                return self::getURLForCategory($url, $id);
+            }
+        }
 
-		return $url;
-	}
+        return $url;
+    }
 
-	/**
-	 * Insert an item in the database
-	 *
-	 * @param array $item
-	 * @return int
-	 */
-	public static function insert(array $item)
-	{
-		$item['created_on'] = BackendModel::getUTCDate();
-	        $item['edited_on'] = BackendModel::getUTCDate();
-		return (int)BackendModel::getContainer()->get('database')->insert('catalog_products', $item);
-	}
+    /**
+     * Insert an item in the database
+     *
+     * @param array $item
+     * @return int
+     */
+    public static function insert(array $item)
+    {
+        $item['created_on'] = BackendModel::getUTCDate();
+        $item['edited_on'] = BackendModel::getUTCDate();
+        return (int)BackendModel::getContainer()->get('database')->insert('catalog_products', $item);
+    }
 
-	/**
-	 * Insert a category in the database
-	 *
-	 * @param array $item
-	 * @return int
-	 */
-	public static function insertCategory(array $item)
-	{
-		$item['created_on'] = BackendModel::getUTCDate();
-	        $item['edited_on'] = BackendModel::getUTCDate();
-		return BackendModel::getContainer()->get('database')->insert('catalog_categories', $item);
-	}
+    /**
+     * Insert a category in the database
+     *
+     * @param array $item
+     * @return int
+     */
+    public static function insertCategory(array $item)
+    {
+        $item['created_on'] = BackendModel::getUTCDate();
+        $item['edited_on'] = BackendModel::getUTCDate();
+        return BackendModel::getContainer()->get('database')->insert('catalog_categories', $item);
+    }
 
-	/**
-	 * Insert a specification in the database
-	 *
-	 * @param array $item
-	 * @return int
-	 */
-	public static function insertSpecification(array $item)
-	{
-		return BackendModel::getContainer()->get('database')->insert('catalog_specifications', $item);
-	}
+    /**
+     * Insert a specification in the database
+     *
+     * @param array $item
+     * @return int
+     */
+    public static function insertSpecification(array $item)
+    {
+        return BackendModel::getContainer()->get('database')->insert('catalog_specifications', $item);
+    }
 
-	/**
-	 * Insert a specification value in the database
-	 *
-	 * @param array $item
-	 * @return int
-	 */
-	public static function insertSpecificationValue(array $item)
-	{
-		return BackendModel::getContainer()->get('database')->insert('catalog_specifications_values', $item);
-	}
+    /**
+     * Insert a specification value in the database
+     *
+     * @param array $item
+     * @return int
+     */
+    public static function insertSpecificationValue(array $item)
+    {
+        return BackendModel::getContainer()->get('database')->insert('catalog_specifications_values', $item);
+    }
 
-	/**
-	 * Insert a related product in the database
-	 *
-	 * @param string $item
-	 * @return int
-	 */
-	private static function insertRelatedProduct($item)
-	{
-		return (int)BackendModel::getContainer()->get('database')->insert('catalog_related_products', $item);
-	}
+    /**
+     * Insert a related product in the database
+     *
+     * @param string $item
+     * @return int
+     */
+    private static function insertRelatedProduct($item)
+    {
+        return (int)BackendModel::getContainer()->get('database')->insert('catalog_related_products', $item);
+    }
 
-	/**
-	 * Insert a image in the database
-	 *
-	 * @param string $item
-	 * @return int
-	 */
-	private static function insertImage($item)
-	{
-		return (int)BackendModel::getContainer()->get('database')->insert('catalog_images', $item);
-	}
+    /**
+     * Insert a image in the database
+     *
+     * @param string $item
+     * @return int
+     */
+    private static function insertImage($item)
+    {
+        return (int)BackendModel::getContainer()->get('database')->insert('catalog_images', $item);
+    }
 
-	/**
-	 * Insert a file in the database
-	 *
-	 * @param string $item
-	 * @return int
-	 */
-	private static function insertFile($item)
-	{
-		return (int)BackendModel::getContainer()->get('database')->insert('catalog_files', $item);
-	}
+    /**
+     * Insert a file in the database
+     *
+     * @param string $item
+     * @return int
+     */
+    private static function insertFile($item)
+    {
+        return (int)BackendModel::getContainer()->get('database')->insert('catalog_files', $item);
+    }
 
-	/**
-	 * Insert a video in the database
-	 *
-	 * @param string $item
-	 * @return int
-	 */
-	private static function insertVideo($item)
-	{
-		return (int)BackendModel::getContainer()->get('database')->insert('catalog_videos', $item);
-	}
+    /**
+     * Insert a video in the database
+     *
+     * @param string $item
+     * @return int
+     */
+    private static function insertVideo($item)
+    {
+        return (int)BackendModel::getContainer()->get('database')->insert('catalog_videos', $item);
+    }
 
-	/**
-	 * Insert a brand in the database
-	 *
-	 * @param array $item
-	 * @return int
-	 */
-	public static function insertBrand(array $item)
-	{
-		$item['created_on'] = BackendModel::getUTCDate();
-	        $item['edited_on'] = BackendModel::getUTCDate();
-		return BackendModel::getContainer()->get('database')->insert('catalog_brands', $item);
-	}
+    /**
+     * Insert a brand in the database
+     *
+     * @param array $item
+     * @return int
+     */
+    public static function insertBrand(array $item)
+    {
+        $item['created_on'] = BackendModel::getUTCDate();
+        $item['edited_on'] = BackendModel::getUTCDate();
+        return BackendModel::getContainer()->get('database')->insert('catalog_brands', $item);
+    }
 
-	/**
-	 * Is this category allowed to be deleted?
-	 *
-	 * @return    bool
-	 * @param    int $id The category id to check.
-	 */
-	public static function isCategoryAllowedToBeDeleted($id)
-	{
-		return !(bool)BackendModel::getContainer()->get('database')->getVar('SELECT COUNT(i.id)
+    /**
+     * Is this category allowed to be deleted?
+     *
+     * @return    bool
+     * @param    int $id The category id to check.
+     */
+    public static function isCategoryAllowedToBeDeleted($id)
+    {
+        return !(bool)BackendModel::getContainer()->get('database')->getVar('SELECT COUNT(i.id)
 											FROM catalog_products AS i
 											INNER JOIN catalog_categories AS c
 											WHERE i.category_id = ? OR c.parent_id = ?
 											', array((int)$id, (int)$id));
-	}
+    }
 
-	/**
-	 * Is this brand allowed to be deleted?
-	 *
-	 * @return    bool
-	 * @param    int $id The category id to check.
-	 */
-	public static function isBrandAllowedToBeDeleted($id)
-	{
-		return !(bool)BackendModel::getContainer()->get('database')->getVar('SELECT COUNT(i.id)
+    /**
+     * Is this brand allowed to be deleted?
+     *
+     * @return    bool
+     * @param    int $id The category id to check.
+     */
+    public static function isBrandAllowedToBeDeleted($id)
+    {
+        return !(bool)BackendModel::getContainer()->get('database')->getVar('SELECT COUNT(i.id)
 											FROM catalog_products AS i
 											INNER JOIN catalog_brands AS c
 											WHERE i.brand_id = ?
 											', array((int)$id));
-	}
+    }
 
-	/**
-	 * Recalculate the commentcount
-	 *
-	 * @param array $ids The id(s) of the product wherefore the commentcount should be recalculated.
-	 * @return bool
-	 */
-	public static function reCalculateCommentCount(array $ids)
-	{
-		// validate
-		if(empty($ids)) return false;
+    /**
+     * Recalculate the commentcount
+     *
+     * @param array $ids The id(s) of the product wherefore the commentcount should be recalculated.
+     * @return bool
+     */
+    public static function reCalculateCommentCount(array $ids)
+    {
+        // validate
+        if (empty($ids)) {
+            return false;
+        }
 
-		// make unique ids
-		$ids = array_unique($ids);
+        // make unique ids
+        $ids = array_unique($ids);
 
-		// get db
-		$db = BackendModel::getContainer()->get('database');
+        // get db
+        $db = BackendModel::getContainer()->get('database');
 
-		// get counts
-		$commentCounts = (array)$db->getPairs('SELECT i.product_id, COUNT(i.id) AS comment_count
+        // get counts
+        $commentCounts = (array)$db->getPairs('SELECT i.product_id, COUNT(i.id) AS comment_count
 			 FROM catalog_comments AS i
 			 INNER JOIN catalog_products AS p ON i.product_id = p.id AND i.language = p.language
 			 WHERE i.status = ? AND i.product_id IN (' . implode(',', $ids) . ') AND i.language = ?
 			 GROUP BY i.product_id', array('published', BL::getWorkingLanguage()));
 
-		foreach($ids as $id)
-		{
-			// get count
-			$count = (isset($commentCounts[$id])) ? (int)$commentCounts[$id] : 0;
+        foreach ($ids as $id) {
+            // get count
+            $count = (isset($commentCounts[$id])) ? (int)$commentCounts[$id] : 0;
 
-			// update
-			$db->update('catalog_products', array('num_comments' => $count), 'id = ? AND language = ?', array($id, BL::getWorkingLanguage()));
-		}
+            // update
+            $db->update('catalog_products', array('num_comments' => $count), 'id = ? AND language = ?', array($id, BL::getWorkingLanguage()));
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	/**
-	 * Save or update related product (values)
-	 *
-	 * @param int $productId The id of the item where to assign the related projects.
-	 * @param array $relatedProducts The related products for the item.
-	 * @param array [optional] $oRelatedProducts The related products already existing for the item. If not provided a new record will be created.
-	 *
-	 * @return int
-	 */
-	public static function saveRelatedProducts($productId, $relatedProducts, $oRelatedProducts = null)
-	{
-		$item['product_id'] = $productId;
+    /**
+     * Save or update related product (values)
+     *
+     * @param int $productId The id of the item where to assign the related projects.
+     * @param array $relatedProducts The related products for the item.
+     * @param array [optional] $oRelatedProducts The related products already existing for the item. If not provided a new record will be created.
+     *
+     * @return int
+     */
+    public static function saveRelatedProducts($productId, $relatedProducts, $oRelatedProducts = null)
+    {
+        $item['product_id'] = $productId;
 
-		// existing related products
-		if(isset($oRelatedProducts))
-		{
-			// insert new records
-			$newRelatedProducts = array_diff($relatedProducts, $oRelatedProducts);
-			foreach($newRelatedProducts AS $key => $newRelatedProduct)
-			{
-				$item['related_product_id'] = $newRelatedProduct;
-				self::insertRelatedProduct($item);
-			}
+        // existing related products
+        if (isset($oRelatedProducts)) {
+            // insert new records
+            $newRelatedProducts = array_diff($relatedProducts, $oRelatedProducts);
+            foreach ($newRelatedProducts as $key => $newRelatedProduct) {
+                $item['related_product_id'] = $newRelatedProduct;
+                self::insertRelatedProduct($item);
+            }
 
-			// delete old records
-			$oldRelatedProducts = array_diff($oRelatedProducts, $relatedProducts);
-			foreach($oldRelatedProducts AS $key => $oldRelatedProduct)
-			{
-				$item['related_product_id'] = $oldRelatedProduct;
-				self::deleteRelatedProduct($item['product_id'], $item['related_product_id']);
-			}
-		}
-		else
-		{
-			// new related products
-			// insert new records
-			foreach($relatedProducts AS $key => $relatedProduct)
-			{
-				$item['related_product_id'] = $relatedProduct;
-				self::insertRelatedProduct($item);
-			}
-		}
-	}
+            // delete old records
+            $oldRelatedProducts = array_diff($oRelatedProducts, $relatedProducts);
+            foreach ($oldRelatedProducts as $key => $oldRelatedProduct) {
+                $item['related_product_id'] = $oldRelatedProduct;
+                self::deleteRelatedProduct($item['product_id'], $item['related_product_id']);
+            }
+        } else {
+            // new related products
+            // insert new records
+            foreach ($relatedProducts as $key => $relatedProduct) {
+                $item['related_product_id'] = $relatedProduct;
+                self::insertRelatedProduct($item);
+            }
+        }
+    }
 
-	/**
-	 * Save or update a image
-	 *
-	 * @param array $item
-	 * @return int
-	 */
-	public static function saveImage(array $item)
-	{
-		// update image
-		if(isset($item['id']) && self::existsImage($item['id']))
-		{
-			self::updateImage($item);
-		}
-		else
-		{
-			// insert image
-			$item['id'] = self::insertImage($item);
-		}
+    /**
+     * Save or update a image
+     *
+     * @param array $item
+     * @return int
+     */
+    public static function saveImage(array $item)
+    {
+        // update image
+        if (isset($item['id']) && self::existsImage($item['id'])) {
+            self::updateImage($item);
+        } else {
+            // insert image
+            $item['id'] = self::insertImage($item);
+        }
 
-		BackendModel::invalidateFrontendCache('productsCache');
-		return (int)$item['id'];
-	}
+        BackendModel::invalidateFrontendCache('productsCache');
+        return (int)$item['id'];
+    }
 
-	/**
-	 * Save or update a file
-	 *
-	 * @param array $item
-	 * @return int
-	 */
-	public static function saveFile(array $item)
-	{
-		// update file
-		if(isset($item['id']) && self::existsFile($item['id']))
-		{
-			self::updateFile($item);
-		}
-		else
-		{
-			// insert file
-			$item['id'] = self::insertFile($item);
-		}
+    /**
+     * Save or update a file
+     *
+     * @param array $item
+     * @return int
+     */
+    public static function saveFile(array $item)
+    {
+        // update file
+        if (isset($item['id']) && self::existsFile($item['id'])) {
+            self::updateFile($item);
+        } else {
+            // insert file
+            $item['id'] = self::insertFile($item);
+        }
 
-		BackendModel::invalidateFrontendCache('productsCache');
-		return (int)$item['id'];
-	}
+        BackendModel::invalidateFrontendCache('productsCache');
+        return (int)$item['id'];
+    }
 
-	/**
-	 * Save or update a video
-	 *
-	 * @param array $item
-	 * @return int
-	 */
-	public static function saveVideo(array $item)
-	{
-		// update video
-		if(isset($item['id']) && self::existsVideo($item['id']))
-		{
-			self::updateVideo($item);
-		}
-		else
-		{
-			// insert video
-			$item['id'] = self::insertVideo($item);
-		}
+    /**
+     * Save or update a video
+     *
+     * @param array $item
+     * @return int
+     */
+    public static function saveVideo(array $item)
+    {
+        // update video
+        if (isset($item['id']) && self::existsVideo($item['id'])) {
+            self::updateVideo($item);
+        } else {
+            // insert video
+            $item['id'] = self::insertVideo($item);
+        }
 
-		BackendModel::invalidateFrontendCache('productsCache');
-		return (int)$item['id'];
-	}
+        BackendModel::invalidateFrontendCache('productsCache');
+        return (int)$item['id'];
+    }
 
-	/**
-	 * Updates an item
-	 *
-	 * @param array $item
-	 */
-	public static function update(array $item)
-	{
-		$item['edited_on'] = BackendModel::getUTCDate();
-		BackendModel::getContainer()->get('database')->update('catalog_products', $item, 'id = ?', (int)$item['id']);
-	}
+    /**
+     * Updates an item
+     *
+     * @param array $item
+     */
+    public static function update(array $item)
+    {
+        $item['edited_on'] = BackendModel::getUTCDate();
+        BackendModel::getContainer()->get('database')->update('catalog_products', $item, 'id = ?', (int)$item['id']);
+    }
 
-	/**
-	 * Update a certain category
-	 *
-	 * @param array $item
-	 */
-	public static function updateCategory(array $item)
-	{
-		$item['edited_on'] = BackendModel::getUTCDate();
-		BackendModel::getContainer()->get('database')->update('catalog_categories', $item, 'id = ?', array($item['id']));
-	}
+    /**
+     * Update a certain category
+     *
+     * @param array $item
+     */
+    public static function updateCategory(array $item)
+    {
+        $item['edited_on'] = BackendModel::getUTCDate();
+        BackendModel::getContainer()->get('database')->update('catalog_categories', $item, 'id = ?', array($item['id']));
+    }
 
-	/**
-	 * Update a certain brand
-	 *
-	 * @param array $item
-	 */
-	public static function updateBrand(array $item)
-	{
-		$item['edited_on'] = BackendModel::getUTCDate();
-		BackendModel::getContainer()->get('database')->update('catalog_brands', $item, 'id = ?', array($item['id']));
-	}
+    /**
+     * Update a certain brand
+     *
+     * @param array $item
+     */
+    public static function updateBrand(array $item)
+    {
+        $item['edited_on'] = BackendModel::getUTCDate();
+        BackendModel::getContainer()->get('database')->update('catalog_brands', $item, 'id = ?', array($item['id']));
+    }
 
-	/**
-	 * Update a certain comment
-	 *
-	 * @param array $item The new data.
-	 * @return int
-	 */
-	public static function updateComment(array $item)
-	{
-		return BackendModel::getContainer()->get('database')->update('catalog_comments', $item, 'id = ?', array((int)$item['id']));
-	}
+    /**
+     * Update a certain comment
+     *
+     * @param array $item The new data.
+     * @return int
+     */
+    public static function updateComment(array $item)
+    {
+        return BackendModel::getContainer()->get('database')->update('catalog_comments', $item, 'id = ?', array((int)$item['id']));
+    }
 
-	/**
-	 * Update a certain order
-	 *
-	 * @param array $item The new data.
-	 * @return int
-	 */
-	public static function updateOrder(array $item)
-	{
-		return BackendModel::getContainer()->get('database')->update('catalog_orders', $item, 'id = ?', array((int)$item['id']));
-	}
+    /**
+     * Update a certain order
+     *
+     * @param array $item The new data.
+     * @return int
+     */
+    public static function updateOrder(array $item)
+    {
+        return BackendModel::getContainer()->get('database')->update('catalog_orders', $item, 'id = ?', array((int)$item['id']));
+    }
 
-	/**
-	 * Updates one or more order' status
-	 *
-	 * @param array $ids The id(s) of the order(s) to change the status for.
-	 * @param string $status The new status.
-	 */
-	public static function updateOrderStatuses($ids, $status)
-	{
-		// make sure $ids is an array
-		$ids = (array)$ids;
+    /**
+     * Updates one or more order' status
+     *
+     * @param array $ids The id(s) of the order(s) to change the status for.
+     * @param string $status The new status.
+     */
+    public static function updateOrderStatuses($ids, $status)
+    {
+        // make sure $ids is an array
+        $ids = (array)$ids;
 
-		// loop and cast to integers
-		foreach($ids as &$id) $id = (int)$id;
+        // loop and cast to integers
+        foreach ($ids as &$id) {
+            $id = (int)$id;
+        }
 
-		// create an array with an equal amount of questionmarks as ids provided
-		$idPlaceHolders = array_fill(0, count($ids), '?');
+        // create an array with an equal amount of questionmarks as ids provided
+        $idPlaceHolders = array_fill(0, count($ids), '?');
 
-		// get the items and their languages
-		$items = (array)BackendModel::getContainer()->get('database')->getPairs('SELECT i.id, i.status
+        // get the items and their languages
+        $items = (array)BackendModel::getContainer()->get('database')->getPairs('SELECT i.id, i.status
 			 FROM catalog_orders AS i
 			 WHERE i.id IN (' . implode(', ', $idPlaceHolders) . ')', $ids, 'id');
 
-		// only proceed if there are items
-		if(!empty($items))
-		{
-			// get the ids
-			$itemIds = array_keys($items);
+        // only proceed if there are items
+        if (!empty($items)) {
+            // get the ids
+            $itemIds = array_keys($items);
 
-			// update records
-			BackendModel::getContainer()->get('database')->execute('UPDATE catalog_orders
+            // update records
+            BackendModel::getContainer()->get('database')->execute('UPDATE catalog_orders
 				 SET status = ?
 				 WHERE id IN (' . implode(', ', $idPlaceHolders) . ')', array_merge(array((string)$status), $ids));
-		}
-	}
+        }
+    }
 
-	/**
-	 * Updates one or more comments' status
-	 *
-	 * @param array $ids The id(s) of the comment(s) to change the status for.
-	 * @param string $status The new status.
-	 */
-	public static function updateCommentStatuses($ids, $status)
-	{
-		// make sure $ids is an array
-		$ids = (array)$ids;
+    /**
+     * Updates one or more comments' status
+     *
+     * @param array $ids The id(s) of the comment(s) to change the status for.
+     * @param string $status The new status.
+     */
+    public static function updateCommentStatuses($ids, $status)
+    {
+        // make sure $ids is an array
+        $ids = (array)$ids;
 
-		// loop and cast to integers
-		foreach($ids as &$id) $id = (int)$id;
+        // loop and cast to integers
+        foreach ($ids as &$id) {
+            $id = (int)$id;
+        }
 
-		// create an array with an equal amount of questionmarks as ids provided
-		$idPlaceHolders = array_fill(0, count($ids), '?');
+        // create an array with an equal amount of questionmarks as ids provided
+        $idPlaceHolders = array_fill(0, count($ids), '?');
 
-		// get the items and their languages
-		$items = (array)BackendModel::getContainer()->get('database')->getPairs('SELECT i.product_id, i.language
+        // get the items and their languages
+        $items = (array)BackendModel::getContainer()->get('database')->getPairs('SELECT i.product_id, i.language
 			 FROM catalog_comments AS i
 			 WHERE i.id IN (' . implode(', ', $idPlaceHolders) . ')', $ids, 'product_id');
 
-		// only proceed if there are items
-		if(!empty($items))
-		{
-			// get the ids
-			$itemIds = array_keys($items);
+        // only proceed if there are items
+        if (!empty($items)) {
+            // get the ids
+            $itemIds = array_keys($items);
 
-			// get the unique languages
-			$languages = array_unique(array_values($items));
+            // get the unique languages
+            $languages = array_unique(array_values($items));
 
-			// update records
-			BackendModel::getContainer()->get('database')->execute('UPDATE catalog_comments
+            // update records
+            BackendModel::getContainer()->get('database')->execute('UPDATE catalog_comments
 				 SET status = ?
 				 WHERE id IN (' . implode(', ', $idPlaceHolders) . ')', array_merge(array((string)$status), $ids));
 
-			// recalculate the comment count
-			self::reCalculateCommentCount($itemIds);
+            // recalculate the comment count
+            self::reCalculateCommentCount($itemIds);
 
-			// invalidate the cache for blog
-			foreach($languages as $language) BackendModel::invalidateFrontendCache('catalog', $language);
-		}
-	}
+            // invalidate the cache for blog
+            foreach ($languages as $language) {
+                BackendModel::invalidateFrontendCache('catalog', $language);
+            }
+        }
+    }
 
-	/**
-	 * Update a certain specification
-	 *
-	 * @param int $id
-	 * @param array $item
-	 */
-	public static function updateSpecification($id, $item)
-	{
-		BackendModel::getContainer()->get('database')->update('catalog_specifications', $item, 'id = ?', array($id));
-	}
+    /**
+     * Update a certain specification
+     *
+     * @param int $id
+     * @param array $item
+     */
+    public static function updateSpecification($id, $item)
+    {
+        BackendModel::getContainer()->get('database')->update('catalog_specifications', $item, 'id = ?', array($id));
+    }
 
-	/**
-	 * Update value of a certain specification
-	 *
-	 * @param int $specificationId
-	 * @param int $productId
-	 * @param array $item
-	 */
-	public static function updateSpecificationValue($specificationId, $productId, $item)
-	{
-		BackendModel::getContainer()->get('database')->update('catalog_specifications_values', $item, 'specification_id = ? AND product_id = ?', array((int)$specificationId, (int)$productId));
-	}
+    /**
+     * Update value of a certain specification
+     *
+     * @param int $specificationId
+     * @param int $productId
+     * @param array $item
+     */
+    public static function updateSpecificationValue($specificationId, $productId, $item)
+    {
+        BackendModel::getContainer()->get('database')->update('catalog_specifications_values', $item, 'specification_id = ? AND product_id = ?', array((int)$specificationId, (int)$productId));
+    }
 
-	/**
-	 * @param array $item
-	 * @return int
-	 */
-	public static function updateImage(array $item)
-	{
-		BackendModel::invalidateFrontendCache('productsCache');
-		return (int)BackendModel::getContainer()->get('database')->update('catalog_images', $item, 'id = ?', array($item['id']));
-	}
+    /**
+     * @param array $item
+     * @return int
+     */
+    public static function updateImage(array $item)
+    {
+        BackendModel::invalidateFrontendCache('productsCache');
+        return (int)BackendModel::getContainer()->get('database')->update('catalog_images', $item, 'id = ?', array($item['id']));
+    }
 
-	/**
-	 * @param array $item
-	 * @return int
-	 */
-	public static function updateFile(array $item)
-	{
-		BackendModel::invalidateFrontendCache('productsCache');
-		return (int)BackendModel::getContainer()->get('database')->update('catalog_files', $item, 'id = ?', array($item['id']));
-	}
+    /**
+     * @param array $item
+     * @return int
+     */
+    public static function updateFile(array $item)
+    {
+        BackendModel::invalidateFrontendCache('productsCache');
+        return (int)BackendModel::getContainer()->get('database')->update('catalog_files', $item, 'id = ?', array($item['id']));
+    }
 
-	/**
-	 * @param array $item
-	 * @return int
-	 */
-	public static function updateVideo(array $item)
-	{
-		BackendModel::invalidateFrontendCache('productsCache');
-		return (int)BackendModel::getContainer()->get('database')->update('catalog_videos', $item, 'id = ?', array($item['id']));
-	}
+    /**
+     * @param array $item
+     * @return int
+     */
+    public static function updateVideo(array $item)
+    {
+        BackendModel::invalidateFrontendCache('productsCache');
+        return (int)BackendModel::getContainer()->get('database')->update('catalog_videos', $item, 'id = ?', array($item['id']));
+    }
 }

--- a/src/Backend/Modules/Catalog/Installer/Installer.php
+++ b/src/Backend/Modules/Catalog/Installer/Installer.php
@@ -200,13 +200,11 @@ class Installer extends ModuleInstaller
         $this->insertExtra('Catalog', 'widget', 'RecentProducts', 'RecentProducts', null, 'N', 1006);
         $this->insertExtra('Catalog', 'widget', 'Brands', 'Brands', null, 'N', 1007);
 
-        foreach ($this->getLanguages() as $language)
-        {
+        foreach ($this->getLanguages() as $language) {
             $this->defaultCategoryId = $this->getCategory($language);
 
             // no category exists
-            if ($this->defaultCategoryId == 0)
-            {
+            if ($this->defaultCategoryId == 0) {
                 $this->defaultCategoryId = $this->addCategory($language, 'Default', 'default', 0);
             }
 
@@ -221,8 +219,7 @@ class Installer extends ModuleInstaller
 				 WHERE b.extra_id = ? AND p.language = ?
 				 LIMIT 1',
                 array($catalogId, $language))
-            )
-            {
+            ) {
                 // insert page
                 $this->insertPage(array('title' => 'Catalog',
                         'language' => $language),
@@ -266,8 +263,7 @@ class Installer extends ModuleInstaller
 			 WHERE language = ?
 			 LIMIT 1',
             array($language))
-        )
-        {
+        ) {
             // insert sample product
             $productId = $db->insert('catalog_products', array(
                 'category_id' => $this->defaultCategoryId,
@@ -377,7 +373,9 @@ class Installer extends ModuleInstaller
 
             // copy images into files path
             $fs = new Filesystem();
-            if (!$fs->exists(PATH_WWW . '/src/Frontend/Files/Catalog/')) $fs->mkdir(PATH_WWW . '/src/Frontend/Files/Catalog/');
+            if (!$fs->exists(PATH_WWW . '/src/Frontend/Files/Catalog/')) {
+                $fs->mkdir(PATH_WWW . '/src/Frontend/Files/Catalog/');
+            }
             $fs->mirror(PATH_WWW . '/src/Backend/Modules/Catalog/Installer/Data/Images/', PATH_WWW . '/src/Frontend/Files/Catalog/' . $productId);
         }
     }

--- a/src/Frontend/Modules/Catalog/Actions/Brand.php
+++ b/src/Frontend/Modules/Catalog/Actions/Brand.php
@@ -81,16 +81,19 @@ class Brand extends FrontendBaseBlock
      */
     private function getData()
     {
-
         $this->parameters = $this->URL->getParameters();
         $url = end($this->parameters);
 
-        if ($url === null) $this->redirect(FrontendNavigation::getURL(404));
+        if ($url === null) {
+            $this->redirect(FrontendNavigation::getURL(404));
+        }
 
         // get by URL
         $this->record = FrontendCatalogModel::getBrandFromUrl($url);
 
-        if (empty($this->record)) $this->redirect(FrontendNavigation::getURL(404));
+        if (empty($this->record)) {
+            $this->redirect(FrontendNavigation::getURL(404));
+        }
 
         // get products
         $this->products = FrontendCatalogModel::getAllByBrand($this->record['id']);
@@ -108,10 +111,14 @@ class Brand extends FrontendBaseBlock
         $this->pagination['num_pages'] = (int)ceil($this->pagination['num_items'] / $this->pagination['limit']);
 
         // num pages is always equal to at least 1
-        if ($this->pagination['num_pages'] == 0) $this->pagination['num_pages'] = 1;
+        if ($this->pagination['num_pages'] == 0) {
+            $this->pagination['num_pages'] = 1;
+        }
 
         // redirect if the request page doesn't exist
-        if ($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) $this->redirect(FrontendNavigation::getURL(404));
+        if ($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) {
+            $this->redirect(FrontendNavigation::getURL(404));
+        }
 
         // populate calculated fields in pagination
         $this->pagination['requested_page'] = $requestedPage;
@@ -145,8 +152,12 @@ class Brand extends FrontendBaseBlock
         $this->header->addMetaKeywords($this->record['meta_keywords'], ($this->record['meta_keywords_overwrite'] == 'Y'));
 
         // advanced SEO-attributes
-        if (isset($this->record['meta_data']['seo_index'])) $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_index']));
-        if (isset($this->record['meta_data']['seo_follow'])) $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_follow']));
+        if (isset($this->record['meta_data']['seo_index'])) {
+            $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_index']));
+        }
+        if (isset($this->record['meta_data']['seo_follow'])) {
+            $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_follow']));
+        }
 
         // assign items
         $this->tpl->assign('products', $this->products);

--- a/src/Frontend/Modules/Catalog/Actions/Category.php
+++ b/src/Frontend/Modules/Catalog/Actions/Category.php
@@ -84,12 +84,16 @@ class Category extends FrontendBaseBlock
         $this->parameters = $this->URL->getParameters();
         $url = end($this->parameters);
 
-        if ($url === null) $this->redirect(FrontendNavigation::getURL(404));
+        if ($url === null) {
+            $this->redirect(FrontendNavigation::getURL(404));
+        }
 
         // get by URL
         $this->record = FrontendCatalogModel::getCategory($url);
 
-        if (empty($this->record)) $this->redirect(FrontendNavigation::getURL(404));
+        if (empty($this->record)) {
+            $this->redirect(FrontendNavigation::getURL(404));
+        }
 
         // get subcategories
         $this->subcategories = FrontendCatalogModel::getAllCategories($this->record['id'], $this->record['url']);
@@ -113,10 +117,14 @@ class Category extends FrontendBaseBlock
         $this->pagination['num_pages'] = (int)ceil($this->pagination['num_items'] / $this->pagination['limit']);
 
         // num pages is always equal to at least 1
-        if ($this->pagination['num_pages'] == 0) $this->pagination['num_pages'] = 1;
+        if ($this->pagination['num_pages'] == 0) {
+            $this->pagination['num_pages'] = 1;
+        }
 
         // redirect if the request page doesn't exist
-        if ($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) $this->redirect(FrontendNavigation::getURL(404));
+        if ($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) {
+            $this->redirect(FrontendNavigation::getURL(404));
+        }
 
         // populate calculated fields in pagination
         $this->pagination['requested_page'] = $requestedPage;
@@ -140,8 +148,7 @@ class Category extends FrontendBaseBlock
         $baseUrl = FrontendNavigation::getURLForBlock('catalog', 'category');
 
         // get full urls
-        foreach ($paths as $key => $value)
-        {
+        foreach ($paths as $key => $value) {
             $category = FrontendCatalogModel::getCategoryById($key);
             $breadcrumbPaths = FrontendCatalogModel::traverseUp($categories, $category);
             $url = implode('/', $breadcrumbPaths);
@@ -164,8 +171,12 @@ class Category extends FrontendBaseBlock
         $this->header->addMetaKeywords($this->record['meta_keywords'], ($this->record['meta_keywords_overwrite'] == 'Y'));
 
         // advanced SEO-attributes
-        if (isset($this->record['meta_data']['seo_index'])) $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_index']));
-        if (isset($this->record['meta_data']['seo_follow'])) $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_follow']));
+        if (isset($this->record['meta_data']['seo_index'])) {
+            $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_index']));
+        }
+        if (isset($this->record['meta_data']['seo_follow'])) {
+            $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_follow']));
+        }
 
         // assign items
         $this->tpl->assign('products', $this->products);

--- a/src/Frontend/Modules/Catalog/Actions/Checkout.php
+++ b/src/Frontend/Modules/Catalog/Actions/Checkout.php
@@ -76,8 +76,7 @@ class Checkout extends FrontendBaseBlock
         // get cookie
         $this->orderId = Cookie::get('order_id');
 
-        if ($this->orderId)
-        {
+        if ($this->orderId) {
             // get the products
             $this->products = FrontendCatalogModel::getProductsByOrder($this->orderId);
 
@@ -85,8 +84,7 @@ class Checkout extends FrontendBaseBlock
             $this->totalPrice = '0';
 
             // calculate total amount
-            foreach ($this->products as &$product)
-            {
+            foreach ($this->products as &$product) {
                 // calculate total
                 $subtotal = (int)$product['subtotal_price'];
                 $this->totalPrice = (int)$this->totalPrice;
@@ -110,8 +108,12 @@ class Checkout extends FrontendBaseBlock
         $this->personalDataUrl = FrontendNavigation::getURLForBlock('Catalog', 'PersonalData');
         $this->catalogUrl = FrontendNavigation::getURLForBlock('Catalog');
 
-        if (!empty($this->products)) $this->tpl->assign('productsInShoppingCart', $this->products);
-        if (!empty($this->totalPrice)) $this->tpl->assign('totalPrice', $this->totalPrice);
+        if (!empty($this->products)) {
+            $this->tpl->assign('productsInShoppingCart', $this->products);
+        }
+        if (!empty($this->totalPrice)) {
+            $this->tpl->assign('totalPrice', $this->totalPrice);
+        }
 
         $this->tpl->assign('personalDataUrl', $this->personalDataUrl);
         $this->tpl->assign('catalogUrl', $this->catalogUrl);

--- a/src/Frontend/Modules/Catalog/Actions/Detail.php
+++ b/src/Frontend/Modules/Catalog/Actions/Detail.php
@@ -117,7 +117,9 @@ class Detail extends FrontendBaseBlock
     private function getData()
     {
         // validate incoming parameters
-        if ($this->URL->getParameter(1) === null) $this->redirect(FrontendNavigation::getURL(404));
+        if ($this->URL->getParameter(1) === null) {
+            $this->redirect(FrontendNavigation::getURL(404));
+        }
 
         // get information
         $this->record = FrontendCatalogModel::get($this->URL->getParameter(1));
@@ -134,10 +136,14 @@ class Detail extends FrontendBaseBlock
         $this->record['brand'] = $this->brand;
 
         // reset allow comments
-        if (!$this->settings['allow_comments']) $this->record['allow_comments'] = false;
+        if (!$this->settings['allow_comments']) {
+            $this->record['allow_comments'] = false;
+        }
 
         // check if record is not empty
-        if (empty($this->record)) $this->redirect(FrontendNavigation::getURL(404));
+        if (empty($this->record)) {
+            $this->redirect(FrontendNavigation::getURL(404));
+        }
     }
 
     /**
@@ -187,17 +193,27 @@ class Detail extends FrontendBaseBlock
         $this->header->addMetaKeywords($this->record['meta_keywords'], ($this->record['meta_keywords_overwrite'] == 'Y'));
 
         // advanced SEO-attributes
-        if (isset($this->record['meta_data']['seo_index'])) $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_index']));
-        if (isset($this->record['meta_data']['seo_follow'])) $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_follow']));
+        if (isset($this->record['meta_data']['seo_index'])) {
+            $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_index']));
+        }
+        if (isset($this->record['meta_data']['seo_follow'])) {
+            $this->header->addMetaData(array('name' => 'robots', 'content' => $this->record['meta_data']['seo_follow']));
+        }
 
         // assign item information
         $this->tpl->assign('item', $this->record);
 
-        if (!empty($this->relatedProducts)) $this->tpl->assign('related', $this->relatedProducts);
+        if (!empty($this->relatedProducts)) {
+            $this->tpl->assign('related', $this->relatedProducts);
+        }
 
         $this->tpl->assign('images', $this->record['images']);
-        if ($this->videos != null) $this->tpl->assign('videos', $this->videos);
-        if ($this->files != null) $this->tpl->assign('files', $this->files);
+        if ($this->videos != null) {
+            $this->tpl->assign('videos', $this->videos);
+        }
+        if ($this->files != null) {
+            $this->tpl->assign('files', $this->files);
+        }
         $this->tpl->assign('specifications', $this->specifications);
         $this->tpl->assign('tags', $this->tags);
         //$this->tpl->assign('related', $this->relatedProducts);
@@ -205,7 +221,9 @@ class Detail extends FrontendBaseBlock
         // count comments
         $commentCount = count($this->comments);
 
-        if ($commentCount > 1) $this->tpl->assign('commentsMultiple', true);
+        if ($commentCount > 1) {
+            $this->tpl->assign('commentsMultiple', true);
+        }
 
         // assign the comments
         $this->tpl->assign('commentsCount', $commentCount);
@@ -215,10 +233,15 @@ class Detail extends FrontendBaseBlock
         $this->frm->parse($this->tpl);
 
         // some options
-        if ($this->URL->getParameter('comment', 'string') == 'moderation') $this->tpl->assign('commentIsInModeration', true);
-        if ($this->URL->getParameter('comment', 'string') == 'spam') $this->tpl->assign('commentIsSpam', true);
-        if ($this->URL->getParameter('comment', 'string') == 'true') $this->tpl->assign('commentIsAdded', true);
-
+        if ($this->URL->getParameter('comment', 'string') == 'moderation') {
+            $this->tpl->assign('commentIsInModeration', true);
+        }
+        if ($this->URL->getParameter('comment', 'string') == 'spam') {
+            $this->tpl->assign('commentIsSpam', true);
+        }
+        if ($this->URL->getParameter('comment', 'string') == 'true') {
+            $this->tpl->assign('commentIsAdded', true);
+        }
     }
 
     /**
@@ -230,22 +253,24 @@ class Detail extends FrontendBaseBlock
         $commentsAllowed = (isset($this->settings['allow_comments']) && $this->settings['allow_comments']);
 
         // comments aren't allowed so we don't have to validate
-        if (!$commentsAllowed) return false;
+        if (!$commentsAllowed) {
+            return false;
+        }
 
         // is the form submitted
-        if ($this->frm->isSubmitted())
-        {
+        if ($this->frm->isSubmitted()) {
             // cleanup the submitted fields, ignore fields that were added by hackers
             $this->frm->cleanupFields();
 
             // does the key exists?
-            if (\SpoonSession::exists('catalog_comment_' . $this->record['id']))
-            {
+            if (\SpoonSession::exists('catalog_comment_' . $this->record['id'])) {
                 // calculate difference
                 $diff = time() - (int)\SpoonSession::get('catalog_comment_' . $this->record['id']);
 
                 // calculate difference, it it isn't 10 seconds the we tell the user to slow down
-                if ($diff < 10 && $diff != 0) $this->frm->getField('message')->addError(FL::err('CommentTimeout'));
+                if ($diff < 10 && $diff != 0) {
+                    $this->frm->getField('message')->addError(FL::err('CommentTimeout'));
+                }
             }
 
             // validate required fields
@@ -254,14 +279,12 @@ class Detail extends FrontendBaseBlock
             $this->frm->getField('message')->isFilled(FL::err('MessageIsRequired'));
 
             // validate optional fields
-            if ($this->frm->getField('website')->isFilled() && $this->frm->getField('website')->getValue() != 'http://')
-            {
+            if ($this->frm->getField('website')->isFilled() && $this->frm->getField('website')->getValue() != 'http://') {
                 $this->frm->getField('website')->isURL(FL::err('InvalidURL'));
             }
 
             // no errors?
-            if ($this->frm->isCorrect())
-            {
+            if ($this->frm->isCorrect()) {
                 // get module setting
                 $spamFilterEnabled = (isset($this->settings['spamfilter']) && $this->settings['spamfilter']);
                 $moderationEnabled = (isset($this->settings['moderation']) && $this->settings['moderation']);
@@ -270,7 +293,9 @@ class Detail extends FrontendBaseBlock
                 $author = $this->frm->getField('author')->getValue();
                 $email = $this->frm->getField('email')->getValue();
                 $website = $this->frm->getField('website')->getValue();
-                if (trim($website) == '' || $website == 'http://') $website = null;
+                if (trim($website) == '' || $website == 'http://') {
+                    $website = null;
+                }
                 $text = $this->frm->getField('message')->getValue();
 
                 // build array
@@ -289,23 +314,27 @@ class Detail extends FrontendBaseBlock
                 $redirectLink = $permaLink;
 
                 // is moderation enabled
-                if ($moderationEnabled)
-                {
+                if ($moderationEnabled) {
                     // if the commenter isn't moderated before alter the comment status so it will appear in the moderation queue
-                    if (!FrontendCatalogModel::isModerated($author, $email)) $comment['status'] = 'moderation';
+                    if (!FrontendCatalogModel::isModerated($author, $email)) {
+                        $comment['status'] = 'moderation';
+                    }
                 }
 
                 // should we check if the item is spam
-                if ($spamFilterEnabled)
-                {
+                if ($spamFilterEnabled) {
                     // check for spam
                     $result = FrontendModel::isSpam($text, SITE_URL . $permaLink, $author, $email, $website);
 
                     // if the comment is spam alter the comment status so it will appear in the spam queue
-                    if ($result) $comment['status'] = 'spam';
+                    if ($result) {
+                        $comment['status'] = 'spam';
+                    }
 
                     // if the status is unknown then we should moderate it manually
-                    elseif ($result == 'unknown') $comment['status'] = 'moderation';
+                    elseif ($result == 'unknown') {
+                        $comment['status'] = 'moderation';
+                    }
                 }
 
                 // insert comment
@@ -315,16 +344,26 @@ class Detail extends FrontendBaseBlock
                 FrontendModel::triggerEvent('catalog', 'after_add_comment', array('comment' => $comment));
 
                 // append a parameter to the URL so we can show moderation
-                if (strpos($redirectLink, '?') === false)
-                {
-                    if ($comment['status'] == 'moderation') $redirectLink .= '?comment=moderation#' . FL::act('Comment');
-                    if ($comment['status'] == 'spam') $redirectLink .= '?comment=spam#' . FL::act('Comment');
-                    if ($comment['status'] == 'published') $redirectLink .= '?comment=true#comment-' . $comment['id'];
-                } else
-                {
-                    if ($comment['status'] == 'moderation') $redirectLink .= '&comment=moderation#' . FL::act('Comment');
-                    if ($comment['status'] == 'spam') $redirectLink .= '&comment=spam#' . FL::act('Comment');
-                    if ($comment['status'] == 'published') $redirectLink .= '&comment=true#comment-' . $comment['id'];
+                if (strpos($redirectLink, '?') === false) {
+                    if ($comment['status'] == 'moderation') {
+                        $redirectLink .= '?comment=moderation#' . FL::act('Comment');
+                    }
+                    if ($comment['status'] == 'spam') {
+                        $redirectLink .= '?comment=spam#' . FL::act('Comment');
+                    }
+                    if ($comment['status'] == 'published') {
+                        $redirectLink .= '?comment=true#comment-' . $comment['id'];
+                    }
+                } else {
+                    if ($comment['status'] == 'moderation') {
+                        $redirectLink .= '&comment=moderation#' . FL::act('Comment');
+                    }
+                    if ($comment['status'] == 'spam') {
+                        $redirectLink .= '&comment=spam#' . FL::act('Comment');
+                    }
+                    if ($comment['status'] == 'published') {
+                        $redirectLink .= '&comment=true#comment-' . $comment['id'];
+                    }
                 }
 
                 // set title
@@ -338,13 +377,11 @@ class Detail extends FrontendBaseBlock
                 \SpoonSession::set('catalog_comment_' . $this->record['id'], time());
 
                 // store author-data in cookies
-                try
-                {
+                try {
                     Cookie::set('comment_author', $author);
                     Cookie::set('comment_email', $email);
                     Cookie::set('comment_website', $website);
-                } catch (Exception $e)
-                {
+                } catch (Exception $e) {
                     // settings cookies isn't allowed, but because this isn't a real problem we ignore the exception
                 }
 

--- a/src/Frontend/Modules/Catalog/Actions/Index.php
+++ b/src/Frontend/Modules/Catalog/Actions/Index.php
@@ -78,10 +78,14 @@ class Index extends FrontendBaseBlock
         $this->pagination['num_pages'] = (int)ceil($this->pagination['num_items'] / $this->pagination['limit']);
 
         // num pages is always equal to at least 1
-        if ($this->pagination['num_pages'] == 0) $this->pagination['num_pages'] = 1;
+        if ($this->pagination['num_pages'] == 0) {
+            $this->pagination['num_pages'] = 1;
+        }
 
         // redirect if the request page doesn't exist
-        if ($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) $this->redirect(FrontendNavigation::getURL(404));
+        if ($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) {
+            $this->redirect(FrontendNavigation::getURL(404));
+        }
 
         // populate calculated fields in pagination
         $this->pagination['requested_page'] = $requestedPage;

--- a/src/Frontend/Modules/Catalog/Actions/PersonalData.php
+++ b/src/Frontend/Modules/Catalog/Actions/PersonalData.php
@@ -105,8 +105,7 @@ class PersonalData extends FrontendBaseBlock
     private function validateForm()
     {
         // is the form submitted
-        if ($this->frm->isSubmitted())
-        {
+        if ($this->frm->isSubmitted()) {
             // cleanup the submitted fields, ignore fields that were added by hackers
             $this->frm->cleanupFields();
 
@@ -120,8 +119,7 @@ class PersonalData extends FrontendBaseBlock
             $this->frm->getField('hometown')->isFilled(FL::err('MessageIsRequired'));
 
             // correct?
-            if ($this->frm->isCorrect())
-            {
+            if ($this->frm->isCorrect()) {
                 // build array
                 $order['email'] = $this->frm->getField('email')->getValue();
                 $order['fname'] = $this->frm->getField('fname')->getValue();

--- a/src/Frontend/Modules/Catalog/Ajax/SaveShoppingCart.php
+++ b/src/Frontend/Modules/Catalog/Ajax/SaveShoppingCart.php
@@ -50,40 +50,32 @@ class SaveShoppingCart extends FrontendBaseAJAXAction
         $cookieExists = Cookie::exists('enabled');
 
         // check if cookies are set, when true update the order
-        if (isset($cookieOrderId) && FrontendCatalogModel::existsOrder($cookieOrderId) == true)
-        {
+        if (isset($cookieOrderId) && FrontendCatalogModel::existsOrder($cookieOrderId) == true) {
             $this->orderValues['order_id'] = $cookieOrderId;
 
             // action add or update
-            if ($action == 'add-update')
-            {
-                if (FrontendCatalogModel::existsOrderValue($this->orderValues['product_id'], $this->orderValues['order_id']) == true)
-                {
+            if ($action == 'add-update') {
+                if (FrontendCatalogModel::existsOrderValue($this->orderValues['product_id'], $this->orderValues['order_id']) == true) {
                     // update the order values
                     FrontendCatalogModel::updateOrderValue($this->orderValues, $this->orderValues['order_id'], $this->orderValues['product_id']);
                     $this->output(self::OK, null, 'Order values updated.');
-                } else
-                {
+                } else {
                     // insert order values
                     FrontendCatalogModel::insertOrderValue($this->orderValues);
                     $this->output(self::OK, null, 'Order values inserted.');
                 }
-            } else if ($action == 'delete')
-            {
-                if (FrontendCatalogModel::existsOrderValue($this->orderValues['product_id'], $this->orderValues['order_id']) == true)
-                {
+            } elseif ($action == 'delete') {
+                if (FrontendCatalogModel::existsOrderValue($this->orderValues['product_id'], $this->orderValues['order_id']) == true) {
                     // delete the order values
                     FrontendCatalogModel::deleteOrderValue($this->orderValues['order_id'], $this->orderValues['product_id']);
                     $this->output(self::OK, null, 'Order values deleted.');
                 }
             }
-        } else
-        {
+        } else {
             // when no cookies are set, create new cookie and insert order
             $orderId = FrontendCatalogModel::insertOrder();
 
-            if ($orderId != '')
-            {
+            if ($orderId != '') {
                 // set order id
                 $this->orderValues['order_id'] = $orderId;
 

--- a/src/Frontend/Modules/Catalog/Ajax/UpdateCheckoutCart.php
+++ b/src/Frontend/Modules/Catalog/Ajax/UpdateCheckoutCart.php
@@ -78,8 +78,7 @@ class UpdateCheckoutCart extends FrontendBaseAJAXAction
         // get cookie
         $this->orderId = Cookie::get('order_id');
 
-        if ($this->orderId)
-        {
+        if ($this->orderId) {
             // get the products
             $this->products = FrontendCatalogModel::getProductsByOrder($this->orderId);
 
@@ -90,8 +89,7 @@ class UpdateCheckoutCart extends FrontendBaseAJAXAction
             $this->totalPrice = '0';
 
             // calculate total amount
-            foreach ($this->products as &$product)
-            {
+            foreach ($this->products as &$product) {
                 // calculate total
                 $subtotal = (int)$product['subtotal_price'];
                 $this->totalPrice = (int)$this->totalPrice;

--- a/src/Frontend/Modules/Catalog/Ajax/UpdateShoppingCart.php
+++ b/src/Frontend/Modules/Catalog/Ajax/UpdateShoppingCart.php
@@ -95,8 +95,7 @@ class UpdateShoppingCart extends FrontendBaseAJAXAction
         $this->cookiesEnabled = Cookie::hasAllowedCookies();
 
         // check if cookies exists
-        if ($this->orderId || $this->cookiesEnabled == true)
-        {
+        if ($this->orderId || $this->cookiesEnabled == true) {
             // get the products
             $this->products = FrontendCatalogModel::getProductsByOrder($this->orderId);
 
@@ -107,8 +106,7 @@ class UpdateShoppingCart extends FrontendBaseAJAXAction
             $this->totalPrice = '0';
 
             // calculate total amount
-            foreach ($this->products as &$product)
-            {
+            foreach ($this->products as &$product) {
                 // calculate total
                 $subtotal = (int)$product['subtotal_price'];
                 $this->totalPrice = (int)$this->totalPrice;
@@ -130,10 +128,18 @@ class UpdateShoppingCart extends FrontendBaseAJAXAction
         // url for checkout
         $this->overviewUrl = FrontendNavigation::getURLForBlock('Catalog', 'Checkout');
 
-        if (!empty($this->products)) $this->tpl->assign('productsInShoppingCart', $this->products);
-        if (!empty($this->totalPrice)) $this->tpl->assign('totalPrice', $this->totalPrice);
-        if (!empty($this->amountOfProducts)) $this->tpl->assign('amountOfProducts', $this->amountOfProducts);
-        if ($this->cookiesEnabled == true) $this->tpl->assign('cookiesEnabled', $this->cookiesEnabled);
+        if (!empty($this->products)) {
+            $this->tpl->assign('productsInShoppingCart', $this->products);
+        }
+        if (!empty($this->totalPrice)) {
+            $this->tpl->assign('totalPrice', $this->totalPrice);
+        }
+        if (!empty($this->amountOfProducts)) {
+            $this->tpl->assign('amountOfProducts', $this->amountOfProducts);
+        }
+        if ($this->cookiesEnabled == true) {
+            $this->tpl->assign('cookiesEnabled', $this->cookiesEnabled);
+        }
 
         $this->tpl->assign('overviewUrl', $this->overviewUrl);
     }
@@ -155,5 +161,4 @@ class UpdateShoppingCart extends FrontendBaseAJAXAction
         // output
         $this->output(self::OK, $this->tpl->getContent(FRONTEND_PATH . '/Modules/Catalog/Layout/Widgets/ShoppingCartAjax.tpl', false, true));
     }
-
 }

--- a/src/Frontend/Modules/Catalog/Engine/Model.php
+++ b/src/Frontend/Modules/Catalog/Engine/Model.php
@@ -32,8 +32,7 @@ class Model implements FrontendTagsInterface
      */
     public static function get($url = null, $id = null)
     {
-        if (!$id)
-        {
+        if (!$id) {
             $item = (array)FrontendModel::getContainer()->get('database')->getRecord('SELECT i.*,
 				 m.keywords AS meta_keywords, m.keywords_overwrite AS meta_keywords_overwrite,
 				 m.description AS meta_description, m.description_overwrite AS meta_description_overwrite,
@@ -43,8 +42,7 @@ class Model implements FrontendTagsInterface
 				 INNER JOIN catalog_categories AS c ON i.category_id = c.id
 				 INNER JOIN meta AS m2 ON c.meta_id = m2.id
 				 WHERE m.url = ? AND i.language = ?', array((string)$url, FRONTEND_LANGUAGE));
-        } else
-        {
+        } else {
             $item = (array)FrontendModel::getContainer()->get('database')->getRecord('SELECT i.*,
 				 m.keywords AS meta_keywords, m.keywords_overwrite AS meta_keywords_overwrite,
 				 m.description AS meta_description, m.description_overwrite AS meta_description_overwrite,
@@ -57,15 +55,16 @@ class Model implements FrontendTagsInterface
         }
 
         // no results?
-        if (empty($item)) return array();
+        if (empty($item)) {
+            return array();
+        }
 
         // create full url
         $item['full_url'] = FrontendNavigation::getURLForBlock('Catalog', 'Detail') . '/' . $item['url'];
         $item['category_full_url'] = FrontendNavigation::getURLForBlock('Catalog', 'Category') . '/' . $item['category_url'];
 
         // add images
-        if ($images = self::getImages((int)$item['id']))
-        {
+        if ($images = self::getImages((int)$item['id'])) {
             // Use first image as the main image
             $item = array_merge($images[0], $item);
             // Add the other images as array
@@ -106,12 +105,14 @@ class Model implements FrontendTagsInterface
 			 WHERE o.order_id = ?', array((int)$id));
 
         // calculate total amount
-        foreach ($items as &$item)
-        {
+        foreach ($items as &$item) {
             // get image
             $img = FrontendModel::getContainer()->get('database')->getRecord('SELECT * FROM catalog_images WHERE product_id = ? ORDER BY sequence', array((int)$item['product_id']));
-            if ($img) $item['image'] = FRONTEND_FILES_URL . '/catalog/' . $item['product_id'] . '/64x64/' . $img['filename'];
-            else $item['image'] = '/' . APPLICATION . '/modules/catalog/layout/images/dummy.png';
+            if ($img) {
+                $item['image'] = FRONTEND_FILES_URL . '/catalog/' . $item['product_id'] . '/64x64/' . $img['filename'];
+            } else {
+                $item['image'] = '/' . APPLICATION . '/modules/catalog/layout/images/dummy.png';
+            }
 
             // create full url
             $item['full_url'] = FrontendNavigation::getURLForBlock('Catalog', 'Detail') . '/' . $item['url'];
@@ -141,14 +142,15 @@ class Model implements FrontendTagsInterface
 			 ORDER BY i.created_on ASC, i.id DESC LIMIT ?, ?', array(FRONTEND_LANGUAGE, (int)$offset, (int)$limit));
 
         // no results?
-        if (empty($items)) return array();
+        if (empty($items)) {
+            return array();
+        }
 
         // get detail action url
         $detailUrl = FrontendNavigation::getURLForBlock('Catalog', 'Detail');
 
         // prepare items for search
-        foreach ($items as &$item)
-        {
+        foreach ($items as &$item) {
             $item['full_url'] = $detailUrl . '/' . $item['url'];
         }
 
@@ -184,17 +186,21 @@ class Model implements FrontendTagsInterface
 			 ORDER BY i.sequence ASC, i.id DESC LIMIT ?, ?', array($categoryId, FRONTEND_LANGUAGE, (int)$offset, (int)$limit));
 
         // no results?
-        if (empty($items)) return array();
+        if (empty($items)) {
+            return array();
+        }
 
         // get detail action url
         $detailUrl = FrontendNavigation::getURLForBlock('Catalog', 'Detail');
 
         // prepare items for search
-        foreach ($items as &$item)
-        {
+        foreach ($items as &$item) {
             $img = FrontendModel::getContainer()->get('database')->getRecord('SELECT * FROM catalog_images WHERE product_id = ? ORDER BY sequence', array((int)$item['id']));
-            if ($img) $item['image'] = FRONTEND_FILES_URL . '/catalog/' . $item['id'] . '/200x200/' . $img['filename'];
-            else $item['image'] = '/' . APPLICATION . '/modules/catalog/layout/images/dummy.png';
+            if ($img) {
+                $item['image'] = FRONTEND_FILES_URL . '/catalog/' . $item['id'] . '/200x200/' . $img['filename'];
+            } else {
+                $item['image'] = '/' . APPLICATION . '/modules/catalog/layout/images/dummy.png';
+            }
 
             $item['full_url'] = $detailUrl . '/' . $item['url'];
         }
@@ -222,12 +228,11 @@ class Model implements FrontendTagsInterface
         $baseUrl = FrontendNavigation::getURLForBlock('Catalog', 'Category');
 
         // loop items and unserialize
-        foreach ($items as &$row)
-        {
+        foreach ($items as &$row) {
             // set image path
             $img = FrontendModel::getContainer()->get('database')->getRecord('SELECT * FROM catalog_categories WHERE id = ?', array((int)$row['id']));
 
-            if ($img){
+            if ($img) {
                 $row['image'] = FRONTEND_FILES_URL . '/catalog/categories/' . $row['id'] . '/source/' . $img['image'];
                 $row['thumbnail'] = FRONTEND_FILES_URL . '/catalog/categories/' . $row['id'] . '/150x150/' . $img['image'];
             } else {
@@ -236,22 +241,21 @@ class Model implements FrontendTagsInterface
 
             // set nested urls
             $paths = self::traverseUp($items, $row);
-            if (!empty($paths))
-            {
+            if (!empty($paths)) {
                 $url = implode('/', $paths);
                 $row['full_url'] = $baseUrl . '/' . $url;
             }
 
-            if (isset($row['meta_data'])) $row['meta_data'] = @unserialize($row['meta_data']);
+            if (isset($row['meta_data'])) {
+                $row['meta_data'] = @unserialize($row['meta_data']);
+            }
         }
 
         // convert flat array in tree
-        if ($id != null)
-        {
+        if ($id != null) {
             // parent id is given
             $items = self::buildTree($items, $id);
-        } else
-        {
+        } else {
             $items = self::buildTree($items);
         }
 
@@ -274,22 +278,18 @@ class Model implements FrontendTagsInterface
 		 ORDER BY i.publish_on DESC', array('active', 'N'));
 
         // has items
-        if (!empty($items))
-        {
+        if (!empty($items)) {
             // init var
             $link = FrontendNavigation::getURLForBlock('Catalog', 'Detail');
             $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/Catalog/Images', true);
 
             // reset url
-            foreach ($items as &$row)
-            {
+            foreach ($items as &$row) {
                 $row['full_url'] = $link . '/' . $row['url'];
 
                 // image?
-                if (isset($row['image']))
-                {
-                    foreach ($folders as $folder)
-                    {
+                if (isset($row['image'])) {
+                    foreach ($folders as $folder) {
                         $row['image_' . $folder['dirname']] = $folder['url'] . '/' . $folder['dirname'] . '/' . $row['image'];
                     }
                 }
@@ -327,29 +327,24 @@ class Model implements FrontendTagsInterface
         $children = array();
 
         // loop parents
-        foreach ($items as &$item)
-        {
+        foreach ($items as &$item) {
             $children[(!empty($item['parent_id']) ? $item['parent_id'] : 0)][] = &$item;
             unset($item);
         }
 
         // loop children
-        foreach ($items as &$item)
-        {
+        foreach ($items as &$item) {
             // if children
-            if (isset($children[$item['id']]))
-            {
+            if (isset($children[$item['id']])) {
                 // insert
                 $item['children'] = $children[$item['id']];
             }
         }
 
         // check if children exists
-        if (isset($children[$id]))
-        {
+        if (isset($children[$id])) {
             return $children[$id];
-        } else
-        {
+        } else {
             // if no children return empty array
             return array();
         }
@@ -365,13 +360,11 @@ class Model implements FrontendTagsInterface
         $html = '<ul>';
 
         // loop tree
-        foreach ($tree as &$item)
-        {
+        foreach ($tree as &$item) {
             // set parent
             $html .= '<li><a href="' . $item['full_url'] . '">' . $item['title'] . '</a>';
 
-            if (!empty($item['children']))
-            {
+            if (!empty($item['children'])) {
                 $html .= '<ul>' . self::getTreeChildren($item['children']) . '</ul>';
             }
 
@@ -380,11 +373,9 @@ class Model implements FrontendTagsInterface
 
         $html .= "</ul>";
 
-        if ($html == '<ul></ul>')
-        {
+        if ($html == '<ul></ul>') {
             return array();
-        } else
-        {
+        } else {
             return $html;
         }
     }
@@ -399,14 +390,11 @@ class Model implements FrontendTagsInterface
         $html = '';
 
         // loop children tree
-        foreach ($treeChildren as &$item)
-        {
-
+        foreach ($treeChildren as &$item) {
             // set children
             $html .= '<li><a href="' . $item['full_url'] . '">' . $item['title'] . '</a>';
 
-            if (!empty($item['children']))
-            {
+            if (!empty($item['children'])) {
                 $html .= '<ul>' . self::getTreeChildren($item['children']) . '</ul>';
             }
 
@@ -426,14 +414,11 @@ class Model implements FrontendTagsInterface
     public static function traverseUp($items, $item)
     {
         $paths = array();
-        while (!empty($item))
-        {
+        while (!empty($item)) {
             $paths[$item['id']] = $item['url'];
-            if (!empty($items[$item['parent_id']]) && !isset($paths[$item['parent_id']]))
-            {
+            if (!empty($items[$item['parent_id']]) && !isset($paths[$item['parent_id']])) {
                 $item = $items[$item['parent_id']];
-            } else
-            {
+            } else {
                 $paths[$item['id']] = $item['url'];
                 $item = null;
             }
@@ -453,10 +438,8 @@ class Model implements FrontendTagsInterface
      */
     public static function getAllCategories($id = 0, $url = null)
     {
-
         // category id given
-        if ($id != 0)
-        {
+        if ($id != 0) {
             $items = (array)FrontendModel::getContainer()->get('database')->getRecords('SELECT c.id, c.title, m.url, COUNT(p.id) AS total, m.data AS meta_data
 				 FROM catalog_categories AS c
 				 INNER JOIN meta AS m ON c.meta_id = m.id
@@ -464,8 +447,7 @@ class Model implements FrontendTagsInterface
 				 WHERE c.parent_id = ? AND c.language = ?
 				 GROUP BY c.id
 				 ORDER BY c.sequence', array($id, FRONTEND_LANGUAGE), 'id');
-        } else
-        {
+        } else {
             // no category given
             $items = (array)FrontendModel::getContainer()->get('database')->getRecords('SELECT c.id, c.title, m.url, COUNT(p.id) AS total, m.data AS meta_data, parent_id
 				 FROM catalog_categories AS c
@@ -477,12 +459,11 @@ class Model implements FrontendTagsInterface
         }
 
         // loop items and unserialize
-        foreach ($items as &$row)
-        {
+        foreach ($items as &$row) {
             // set image path
             $img = FrontendModel::getContainer()->get('database')->getRecord('SELECT * FROM catalog_categories WHERE id = ?', array((int)$row['id']));
 
-            if ($img){
+            if ($img) {
                 $row['image'] = FRONTEND_FILES_URL . '/catalog/categories/' . $row['id'] . '/source/' . $img['image'];
                 $row['thumbnail'] = FRONTEND_FILES_URL . '/catalog/categories/' . $row['id'] . '/150x150/' . $img['image'];
             } else {
@@ -490,15 +471,15 @@ class Model implements FrontendTagsInterface
             };
 
             // create full url
-            if ($url != null)
-            {
+            if ($url != null) {
                 $row['full_url'] = FrontendNavigation::getURLForBlock('Catalog', 'Category') . '/' . $url . '/' . $row['url'];
-            } else
-            {
+            } else {
                 $row['full_url'] = FrontendNavigation::getURLForBlock('Catalog', 'Category') . '/' . $row['url'];
             }
 
-            if (isset($row['meta_data'])) $row['meta_data'] = @unserialize($row['meta_data']);
+            if (isset($row['meta_data'])) {
+                $row['meta_data'] = @unserialize($row['meta_data']);
+            }
         }
 
         return $items;
@@ -521,7 +502,9 @@ class Model implements FrontendTagsInterface
 			 WHERE m.url = ? AND i.language = ?', array((string)$URL, FRONTEND_LANGUAGE));
 
         // no results?
-        if (empty($item)) return array();
+        if (empty($item)) {
+            return array();
+        }
 
         // create full url
         $item['full_url'] = FrontendNavigation::getURLForBlock('Catalog', 'Category') . '/' . $item['url'];
@@ -546,7 +529,9 @@ class Model implements FrontendTagsInterface
 			 WHERE i.id = ? AND i.language = ?', array((int)$id, FRONTEND_LANGUAGE));
 
         // no results?
-        if (empty($item)) return array();
+        if (empty($item)) {
+            return array();
+        }
 
         // create full url
         $item['full_url'] = FrontendNavigation::getURLForBlock('Catalog', 'Category') . '/' . $item['url'];
@@ -583,8 +568,7 @@ class Model implements FrontendTagsInterface
 			 ORDER BY c.id ASC', array((int)$id, 'published', FRONTEND_LANGUAGE));
 
         // loop comments and create gravatar id
-        foreach ($comments as &$row)
-        {
+        foreach ($comments as &$row) {
             $row['gravatar_id'] = md5($row['email']);
         }
 
@@ -609,8 +593,7 @@ class Model implements FrontendTagsInterface
         $link = FrontendNavigation::getURLForBlock('Catalog', 'Category');
 
         // build the item urls
-        foreach ($items as &$item)
-        {
+        foreach ($items as &$item) {
             $basePath = FRONTEND_FILES_URL . '/Catalog/' . $item['product_id'];
             $item['image'] = $basePath . '/source/' . $item['filename'];
             $item['image_icon'] = $basePath . '/64x64/' . $item['filename'];
@@ -637,34 +620,30 @@ class Model implements FrontendTagsInterface
 		 ORDER BY i.sequence', array((int)$id));
 
         // build the image thumbnail for youtube/vimeo
-        foreach ($items as &$item)
-        {
+        foreach ($items as &$item) {
             // YOUTUBE
-            if (strpos($item['embedded_url'], 'youtube') !== false)
-            {
+            if (strpos($item['embedded_url'], 'youtube') !== false) {
                 $ytQuery = parse_url($item['embedded_url'], PHP_URL_QUERY);
                 parse_str($ytQuery, $ytData);
 
-                if (isset($ytData['v']))
-                {
+                if (isset($ytData['v'])) {
                     $item['video_id'] = $ytData['v'];
                     $item['url'] = "http://www.youtube.com/v/" . $ytData['v'] . "?fs=1&amp;autoplay=1";
                     $item['image'] = "http://i3.ytimg.com/vi/" . $ytData['v'] . "/default.jpg";
                 }
                 // VIMEO
-            } else if (strpos($item['embedded_url'], 'vimeo') !== false)
-            {
+            } elseif (strpos($item['embedded_url'], 'vimeo') !== false) {
                 $vmLink = str_replace('http://vimeo.com/', 'http://vimeo.com/api/v2/video/', $item['embedded_url']) . '.php';
                 $vmData = unserialize(file_get_contents($vmLink));
 
-                if (isset($vmData[0]['id']))
-                {
-                    $item['video_id'] = $vmData[0]['id'];;
+                if (isset($vmData[0]['id'])) {
+                    $item['video_id'] = $vmData[0]['id'];
+                    ;
                     $item['url'] = "http://player.vimeo.com/video/" . $vmData[0]['id'] . "?autoplay=1";
-                    $item['image'] = $vmData[0]['thumbnail_small'];;
+                    $item['image'] = $vmData[0]['thumbnail_small'];
+                    ;
                 }
-            } else
-            {
+            } else {
                 // NO YOUTUBE OR VIMEO URL GIVEN..
             }
         }
@@ -686,8 +665,7 @@ class Model implements FrontendTagsInterface
 			 ORDER BY i.sequence', array((int)$id));
 
         // build the item url
-        foreach ($items as &$item)
-        {
+        foreach ($items as &$item) {
             $item['url'] = FRONTEND_FILES_URL . '/catalog/' . $item['product_id'] . '/source/' . $item['filename'];
         }
 
@@ -722,8 +700,7 @@ class Model implements FrontendTagsInterface
 
         $relatedProducts = array();
 
-        foreach ($relatedIds as $relatedProduct)
-        {
+        foreach ($relatedIds as $relatedProduct) {
             $relatedProducts[] = self::get(null, $relatedProduct['related_product_id']);
         }
 
@@ -774,8 +751,7 @@ class Model implements FrontendTagsInterface
         $comment['id'] = (int)$db->insert('catalog_comments', $comment);
 
         // recalculate if published
-        if ($comment['status'] == 'published')
-        {
+        if ($comment['status'] == 'published') {
             // num comments
             $numComments = (int)FrontendModel::getContainer()->get('database')->getVar('SELECT COUNT(i.id) AS comment_count
 				 FROM catalog_comments AS i
@@ -851,16 +827,25 @@ class Model implements FrontendTagsInterface
     public static function notifyAdmin(array $comment)
     {
         // don't notify admin in case of spam
-        if ($comment['status'] == 'spam') return;
+        if ($comment['status'] == 'spam') {
+            return;
+        }
 
         // build data for push notification
-        if ($comment['status'] == 'moderation') $key = 'CATALOG_COMMENT_MOD';
-        else $key = 'CATALOG_COMMENT';
+        if ($comment['status'] == 'moderation') {
+            $key = 'CATALOG_COMMENT_MOD';
+        } else {
+            $key = 'CATALOG_COMMENT';
+        }
 
         $author = $comment['author'];
-        if (mb_strlen($author) > 20) $author = mb_substr($author, 0, 19) . '�';
+        if (mb_strlen($author) > 20) {
+            $author = mb_substr($author, 0, 19) . '�';
+        }
         $text = $comment['text'];
-        if (mb_strlen($text) > 50) $text = mb_substr($text, 0, 49) . '�';
+        if (mb_strlen($text) > 50) {
+            $text = mb_substr($text, 0, 49) . '�';
+        }
 
         $alert = array('loc-key' => $key, 'loc-args' => array($author, $text));
 
@@ -879,25 +864,21 @@ class Model implements FrontendTagsInterface
         $backendURL = SITE_URL . FrontendNavigation::getBackendURLForBlock('Comments', 'Catalog') . '#tabModeration';
 
         // notify on all comments
-        if ($notifyByMailOnComment)
-        {
+        if ($notifyByMailOnComment) {
             // init var
             $variables = null;
 
             // comment to moderate
-            if ($comment['status'] == 'moderation')
-            {
+            if ($comment['status'] == 'moderation') {
                 $variables['message'] = vsprintf(FL::msg('CatalogEmailNotificationsNewCommentToModerate'), array($comment['author'], $URL, $comment['product_title'], $backendURL));
-            } elseif ($comment['status'] == 'published')
-            {
+            } elseif ($comment['status'] == 'published') {
                 // comment was published
                 $variables['message'] = vsprintf(FL::msg('CatalogEmailNotificationsNewComment'), array($comment['author'], $URL, $comment['product_title']));
             }
 
             // send the mail
             FrontendMailer::addEmail(FL::msg('NotificationSubject'), FRONTEND_CORE_PATH . '/layout/templates/mails/notification.tpl', $variables);
-        } elseif ($notifyByMailOnCommentToModerate && $comment['status'] == 'moderation')
-        {
+        } elseif ($notifyByMailOnCommentToModerate && $comment['status'] == 'moderation') {
             // only notify on new comments to moderate and if the comment is one to moderate
             // set variables
             $variables['message'] = vsprintf(FL::msg('CatalogEmailNotificationsNewCommentToModerate'), array($comment['author'], $URL, $comment['product_title'], $backendURL));
@@ -1005,8 +986,7 @@ class Model implements FrontendTagsInterface
         $detailUrl = FrontendNavigation::getURLForBlock('Catalog', 'Detail');
 
         // prepare items for search
-        foreach ($items as &$item)
-        {
+        foreach ($items as &$item) {
             $item['full_url'] = $detailUrl . '/' . $item['url'];
         }
 
@@ -1053,7 +1033,9 @@ class Model implements FrontendTagsInterface
 			 WHERE m.url = ?', array((string)$URL));
 
         // no results?
-        if (empty($item)) return array();
+        if (empty($item)) {
+            return array();
+        }
 
         // create full url
         $item['full_url'] = FrontendNavigation::getURLForBlock('Catalog', 'Brand') . '/' . $item['url'];
@@ -1078,17 +1060,21 @@ class Model implements FrontendTagsInterface
 			 ORDER BY i.sequence ASC, i.id DESC LIMIT ?, ?', array($brandId, FRONTEND_LANGUAGE, (int)$offset, (int)$limit));
 
         // no results?
-        if (empty($items)) return array();
+        if (empty($items)) {
+            return array();
+        }
 
         // get detail action url
         $detailUrl = FrontendNavigation::getURLForBlock('Catalog', 'Detail');
 
         // prepare items for search
-        foreach ($items as &$item)
-        {
+        foreach ($items as &$item) {
             $img = FrontendModel::getContainer()->get('database')->getRecord('SELECT * FROM catalog_images WHERE product_id = ? ORDER BY sequence', array((int)$item['id']));
-            if ($img) $item['image'] = FRONTEND_FILES_URL . '/catalog/' . $item['id'] . '/200x200/' . $img['filename'];
-            else $item['image'] = '/' . APPLICATION . '/modules/catalog/layout/images/dummy.png';
+            if ($img) {
+                $item['image'] = FRONTEND_FILES_URL . '/catalog/' . $item['id'] . '/200x200/' . $img['filename'];
+            } else {
+                $item['image'] = '/' . APPLICATION . '/modules/catalog/layout/images/dummy.png';
+            }
 
             $item['full_url'] = $detailUrl . '/' . $item['url'];
         }
@@ -1106,7 +1092,6 @@ class Model implements FrontendTagsInterface
      */
     public static function getAllBrands()
     {
-
         $items = (array)FrontendModel::getContainer()->get('database')->getRecords('SELECT i.id, i.title,i.image, m.url, COUNT(p.id) AS total, m.data AS meta_data
 				 FROM catalog_brands AS i
 				 INNER JOIN meta AS m ON i.meta_id = m.id
@@ -1115,12 +1100,13 @@ class Model implements FrontendTagsInterface
 				 ORDER BY i.sequence', null, 'id');
 
 
-        foreach ($items as &$row)
-        {
+        foreach ($items as &$row) {
             // create full url
             $row['full_url'] = FrontendNavigation::getURLForBlock('Catalog', 'Brand') . '/' . $row['url'];
 
-            if (isset($row['meta_data'])) $row['meta_data'] = @unserialize($row['meta_data']);
+            if (isset($row['meta_data'])) {
+                $row['meta_data'] = @unserialize($row['meta_data']);
+            }
         }
 
         return $items;

--- a/src/Frontend/Modules/Catalog/Widgets/Brands.php
+++ b/src/Frontend/Modules/Catalog/Widgets/Brands.php
@@ -25,7 +25,6 @@ class Brands extends FrontendBaseWidget
      */
     public function execute()
     {
-
         parent::execute();
         $this->loadTemplate();
         $this->parse();

--- a/src/Frontend/Modules/Catalog/Widgets/Categories.php
+++ b/src/Frontend/Modules/Catalog/Widgets/Categories.php
@@ -42,13 +42,14 @@ class Categories extends FrontendBaseWidget
         $tree = FrontendCatalogModel::getCategoriesTree();
 
         // any categories?
-        if (!empty($categories))
-        {
+        if (!empty($categories)) {
             // build link
             $link = FrontendNavigation::getURLForBlock('Catalog', 'Category');
 
             // loop and reset url
-            foreach ($categories as &$row) $row['url'] = $link . '/' . $row['url'];
+            foreach ($categories as &$row) {
+                $row['url'] = $link . '/' . $row['url'];
+            }
         }
 
         // assign comments

--- a/src/Frontend/Modules/Catalog/Widgets/ShoppingCart.php
+++ b/src/Frontend/Modules/Catalog/Widgets/ShoppingCart.php
@@ -37,8 +37,7 @@ class ShoppingCart extends FrontendBaseWidget
     private function getData()
     {
         // check if cookie exists
-        if (!Cookie::exists('order_id'))
-        {
+        if (!Cookie::exists('order_id')) {
             return;
         }
     }


### PR DESCRIPTION
As Fork CMS moves on to the Symfony framework, maybe it's best to make the catalog module code also PSR-2 compliant. The code often uses tabs instead of spaces, faulty braces use (if/else, foreach), ...

More about the standard can be found here: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md

Oh, If you merge the other pull request first, I can pull and fix that code so there won't be any merge conflicts or undoing the code.